### PR TITLE
Build mode: identifier-conservation fixes, research loop, GEPA optimization

### DIFF
--- a/.cursor/scratchpad.md
+++ b/.cursor/scratchpad.md
@@ -1,0 +1,75 @@
+# SERF Build-Mode Scratchpad
+
+## Background and Motivation
+
+Planning is done (docs/SERF_LONG_SHOT_PLAN.md, merged to main via PR #14). The user has
+now directed a move to **build mode**: implement Karpathy's research loop
+(docs/RESEARCH_LOOP.md), use `dspy.GEPA` to prompt-optimize the ER signatures, and iterate
+until SERF's numbers beat its own current baseline / the state of the art, reported
+honestly with protocol labels. Work autonomously; don't consult the user unless
+absolutely necessary. Hard cap: **$100 total in GCP/Gemini credits** for this effort
+(explicit user instruction takes precedence over RESEARCH_LOOP.md's "$100/day" framing).
+
+**Locked-in model policy (explicit user correction, overrides any other model names
+mentioned in RESEARCH_LOOP.md/MISSION.md, which were written by a separate research
+session before this instruction):**
+
+- Task / student LM (all ER pipeline ops): `gemini/gemini-3.5-flash-lite`
+- Reflection LM (GEPA, validation data): `gemini/gemini-3.7-flash`
+- Secondary / "paper" model: `gpt-oss-120b-maas` (Vertex AI MaaS)
+
+Do not use `gemini-3.8-flash`, `gemini-3.1-flash-lite`, or `gpt-oss-20b` anywhere.
+
+## Key Challenges and Analysis
+
+`docs/ID_INVARIANTS.md` §8 audits the current `src/serf/match/uuid_mapper.py` /
+`matcher.py` against the Abzu reference semantics and finds real correctness bugs
+(D1-D8). D1-D3 can silently lose data starting at iteration 2. `RESEARCH_LOOP.md` also
+flags `max_tokens=8192` hardcoded in `matcher.py`, which caused real truncation/record
+loss in a prior baseline run. GEPA-optimizing prompts on top of a leaky pipeline
+produces untrustworthy numbers, so correctness comes first (Stage 1 of the research
+loop), before any optimization (Stage 3).
+
+## High-Level Task Breakdown
+
+1. **Correctness first (Stage 1).** Write the 9 required tests from ID_INVARIANTS.md
+   §9 (should fail against current code per D1-D5), fix D1-D8 + the max_tokens issue,
+   confirm tests pass. Success: all 9 invariant tests pass, full suite still green.
+2. **Experiment infrastructure.** `experiments/log.md` (append-only, RESEARCH_LOOP.md
+   §4 format), a real budget/cost-tracking ledger (`serf.dspy.budget`, currently
+   undocumented in code — check what exists), LM response caching so re-runs are free.
+   Success: a budget guard exists, is wired into matcher/optimizer, and caching is on.
+3. **Baselines (Stage 1 cont'd).** One command per dataset producing: random,
+   exact-string-match, Jaccard/TF-IDF, blocking-recall-ceiling, pairwise-LLM. Success:
+   `serf benchmark --dataset X --baseline all` (or equivalent) prints all five plus the
+   current block-level SERF number, for DBLP-ACM first.
+4. **GEPA optimization (Stage 3).** Build train/val splits from benchmark ground truth
+   (test split sealed), a metric with textual feedback, run `dspy.GEPA` on `BlockMatch`
+   against Gemini 3.5 Flash-Lite with Gemini 3.7 Flash as `reflection_lm`. Success:
+   optimized program improves F1 over hand-written baseline on held-out validation,
+   logged as an experiment with cost.
+5. **Report.** Update experiment log + a summary of what was achieved vs. baseline vs.
+   published numbers (with protocol labels, per RESEARCH_LOOP.md's honesty rules). Open
+   a PR.
+
+## Project Status Board
+
+- [ ] Task 1: Fix identifier-conservation correctness bugs (D1-D8) + max_tokens
+- [ ] Task 2: Experiment log + budget ledger + caching
+- [ ] Task 3: Baseline suite (DBLP-ACM first, then Walmart-Amazon, DBLP-Scholar)
+- [ ] Task 4: GEPA optimization loop
+- [ ] Task 5: Final report + PR
+
+## Executor's Feedback or Assistance Requests
+
+(none yet)
+
+## Lessons
+
+- Model policy is fixed by explicit user instruction: gemini-3.5-flash-lite (task),
+  gemini-3.7-flash (reflection), gpt-oss-120b-maas (secondary). Ignore other model
+  names in RESEARCH_LOOP.md/MISSION.md (written before this instruction, by a
+  different session).
+- `main` already has PR #14 (long-shot plan) merged. This branch is `main` +
+  MISSION/CODING_STANDARDS/ID_INVARIANTS/RESEARCH_LOOP.md copied from the still-open
+  docs PR #19 (not merged, so not touching its other changes).

--- a/.cursor/scratchpad.md
+++ b/.cursor/scratchpad.md
@@ -62,6 +62,21 @@ loop), before any optimization (Stage 3).
 
 ## Executor's Feedback or Assistance Requests
 
+**BLOCKED (user notified, continuing other work in the meantime):** Latest
+instruction is teacher=Gemini 3.5 Flash-Lite, student=`gpt-oss-120b-maas`
+(inverting the earlier student/teacher assignment now that correctness work
+is done). `gpt-oss-120b-maas` requires Vertex AI access (`GOOGLE_CLOUD_PROJECT`
++ Application Default Credentials), which this environment does not have --
+only `GEMINI_API_KEY` is configured as a secret. User supplied a project ID,
+then retracted it ("wrong account") -- not used. `_build_tracked_lm()` in
+`src/serf/dspy/optimize.py` is fully implemented and routes by model name
+(Gemini API key vs. Vertex AI ADC), with tests covering both paths and the
+missing-credential failure mode; it just cannot actually be exercised
+end-to-end against the real gpt-oss-120b-maas endpoint without proper
+Google Cloud credentials being added as a secret (Cursor Dashboard > Cloud
+Agents > Secrets: `GOOGLE_CLOUD_PROJECT` + either
+`GOOGLE_APPLICATION_CREDENTIALS` (service-account key) or equivalent ADC).
+
 **Task 1 complete.** Wrote all 9 required tests from ID_INVARIANTS.md §9
 (`tests/test_id_invariants.py`), ran them against the pre-fix code to find real
 failures empirically rather than trust the audit's reasoning alone, then fixed:

--- a/.cursor/scratchpad.md
+++ b/.cursor/scratchpad.md
@@ -54,7 +54,7 @@ loop), before any optimization (Stage 3).
 
 ## Project Status Board
 
-- [ ] Task 1: Fix identifier-conservation correctness bugs (D1-D8) + max_tokens
+- [x] Task 1: Fix identifier-conservation correctness bugs (D1-D8) + max_tokens
 - [ ] Task 2: Experiment log + budget ledger + caching
 - [ ] Task 3: Baseline suite (DBLP-ACM first, then Walmart-Amazon, DBLP-Scholar)
 - [ ] Task 4: GEPA optimization loop
@@ -62,7 +62,45 @@ loop), before any optimization (Stage 3).
 
 ## Executor's Feedback or Assistance Requests
 
-(none yet)
+**Task 1 complete.** Wrote all 9 required tests from ID_INVARIANTS.md §9
+(`tests/test_id_invariants.py`), ran them against the pre-fix code to find real
+failures empirically rather than trust the audit's reasoning alone, then fixed:
+
+- **D1** (real bug, confirmed via test): `source_ids` now cleared before the LLM
+  call in `map_block`, same as `uuid`/`source_uuids`. Without this, a prior
+  round's real-id provenance collides with this round's block-local mapped ints.
+- **D4** (real bug, confirmed via test): singleton blocks now short-circuit in
+  `resolve_block` before any LLM call, with `match_skip_reason="singleton_block"`.
+- **D5** (real bug, confirmed via test): `_assign_uuids` is now only called when
+  `resolution.was_resolved` is True, so error-recovery and singleton blocks keep
+  their original identity signal.
+- **D6**: mapped ints now start at 1, not 0 (models conflate 0 with null).
+- **D7**: added retry loop (`er.matching.max_retries`/`retry_delay_ms`, already
+  in config.yml but previously unused) around the predictor call.
+- Phase-2 recovery now forces the recovered entity's own id into its own
+  `source_ids` (ID_INVARIANTS.md §5 point 2) — confirmed missing via test.
+- `max_tokens` bug from RESEARCH_LOOP.md: raised from hardcoded 8192 to
+  `er.matching.max_output_tokens` (config, default 65536 — Gemini 3.5
+  Flash-Lite's actual max output, verified via docs).
+- Added a genuine identifier-coverage gate to `evaluate_er_results`
+  (`input_entity_ids` param): the existing `uuid_coverage` check only
+  validates that emitted *references* are valid, not that no record vanished
+  with zero trace. This was a real, previously-untested gap.
+
+**D2 and D3, found NOT to be bugs in this implementation** (empirically —
+wrote the tests from ID_INVARIANTS.md, they passed against the pre-fix code):
+the existing restoration logic already threads prior-round provenance through
+via unconditional cache lookups (`orig_id["source_ids"]`/`src["source_ids"]`),
+which happens to achieve Phase-1-equivalent behavior through different means
+than Abzu's explicit `uuids_to_add_back` map. Kept the tests as regression
+protection regardless, per CODING_STANDARDS.md's testing philosophy.
+
+**D8 (dead `min_block_size` config) deferred**: "Low" severity, no data-loss
+risk, and merging undersized blocks with neighbors is a blocking-algorithm
+design decision that deserves its own pass rather than a rushed fix here.
+Noted for follow-up, not blocking GEPA work.
+
+209 tests pass (was 197 on main), ruff/zuban clean. Moving to Task 2.
 
 ## Lessons
 

--- a/.cursor/scratchpad.md
+++ b/.cursor/scratchpad.md
@@ -57,8 +57,11 @@ loop), before any optimization (Stage 3).
 - [x] Task 1: Fix identifier-conservation correctness bugs (D1-D8) + max_tokens
 - [x] Task 2: Experiment log + budget ledger + caching
 - [x] Task 3: Baseline suite (dblp-acm, abt-buy; dblp-scholar deferred -- large, low priority vs GEPA)
-- [ ] Task 4: GEPA optimization loop
-- [ ] Task 5: Final report + PR
+- [x] Task 4: GEPA optimization loop -- built, validated end-to-end, two real runs
+      logged (one positive on a small curated set, one null result on the full,
+      realistic dataset). See experiments/log.md GEPA-2026-09-07-002 and
+      GEPA-2026-09-08-001.
+- [ ] Task 5: Final report + PR (in progress)
 
 ## Executor's Feedback or Assistance Requests
 
@@ -76,6 +79,27 @@ end-to-end against the real gpt-oss-120b-maas endpoint without proper
 Google Cloud credentials being added as a secret (Cursor Dashboard > Cloud
 Agents > Secrets: `GOOGLE_CLOUD_PROJECT` + either
 `GOOGLE_APPLICATION_CREDENTIALS` (service-account key) or equivalent ADC).
+User said to proceed with Gemini 3.5 Flash-Lite as student in the meantime
+(reverting to the original student=Gemini 3.5 Flash-Lite/teacher=Gemini 3.7
+Flash setup) until Vertex AI is configured.
+
+**Task 4 status at end of session.** Ran a much larger, unfiltered training
+run per explicit instruction (all 98 blocks from the full Abt-Buy dataset,
+49/24/25 train/val/test split, max_metric_calls=150, ~30.5 min, ~$6).
+Result: `baseline_f1 == optimized_f1 == 0.4701` exactly -- GEPA proposed and
+evaluated 6+ candidate instructions but none beat the hand-written original
+on this harder, more realistic distribution, and correctly kept the
+original rather than regressing. Genuine negative result, logged honestly
+(GEPA-2026-09-08-001) rather than hidden or re-run-until-positive. This
+contrasts with the earlier small-scale run (GEPA-2026-09-07-002: 0.95 ->
+1.00 on a 13-block curated set) -- read together, the honest interpretation
+is "the harness works and can show improvement, but a real effect on the
+full, realistic distribution needs either a bigger optimization budget or a
+different lever (e.g. dspy.Flex) than this session had time/budget to test."
+Cumulative Gemini spend: $40.27 of $100 (~40%), all producing either a fixed
+bug or a logged, reproducible result -- none wasted silently. Remaining
+budget (~$60) would support a larger max_metric_calls sweep and/or the
+GPT-OSS-120B-maas run once Vertex AI credentials are available.
 
 **Task 1 complete.** Wrote all 9 required tests from ID_INVARIANTS.md §9
 (`tests/test_id_invariants.py`), ran them against the pre-fix code to find real

--- a/.cursor/scratchpad.md
+++ b/.cursor/scratchpad.md
@@ -55,8 +55,8 @@ loop), before any optimization (Stage 3).
 ## Project Status Board
 
 - [x] Task 1: Fix identifier-conservation correctness bugs (D1-D8) + max_tokens
-- [ ] Task 2: Experiment log + budget ledger + caching
-- [ ] Task 3: Baseline suite (DBLP-ACM first, then Walmart-Amazon, DBLP-Scholar)
+- [x] Task 2: Experiment log + budget ledger + caching
+- [x] Task 3: Baseline suite (dblp-acm, abt-buy; dblp-scholar deferred -- large, low priority vs GEPA)
 - [ ] Task 4: GEPA optimization loop
 - [ ] Task 5: Final report + PR
 
@@ -101,6 +101,48 @@ design decision that deserves its own pass rather than a rushed fix here.
 Noted for follow-up, not blocking GEPA work.
 
 209 tests pass (was 197 on main), ruff/zuban clean. Moving to Task 2.
+
+**Task 2 complete.** LM response caching needs no new code: `dspy.LM(cache=True)`
+is the default and already uses a persistent on-disk cache
+(`~/.dspy_cache`) — a cached re-run is genuinely free, satisfying
+RESEARCH_LOOP.md's T2.6 out of the box. Built `src/serf/dspy/budget.py`:
+`BudgetLedger` (file-backed, survives restarts, one JSON file per named
+ledger under `data/budget/`) and `TrackedLM` (a `dspy.LM` subclass that
+hooks `update_history` -- the single place both the sync and async call
+paths funnel through -- to record litellm's own computed cost per call,
+and checks the ledger before every call). Wired into `EntityMatcher` and
+`generate_er_config`, routing by model name to the `gemini` ($100 cap) or
+`gpt_oss_120b_maas` ($20 cap) ledger. Verified against real calls: cost
+matches hand-computed pricing exactly (e.g. 7 prompt + 2 completion tokens
+on gemini-3.5-flash-lite = $7.1e-6, matching $0.30/$2.50 per 1M list price).
+Created `experiments/log.md` in RESEARCH_LOOP.md's format (adapted to a
+single $100-total cap per explicit instruction, not $100/day).
+
+**Task 3 complete (partial, by design).** Built `src/serf/eval/baselines.py`
+(random, exact-name-match, TF-IDF cosine -- all vectorized/sampled so they
+scale to DBLP-Scholar's ~168M candidate pairs without a Python double loop)
+and a `serf baselines` CLI command that also reports the blocking recall
+ceiling using the real `SemanticBlockingPipeline`. Ran on dblp-acm and
+abt-buy (logged in experiments/log.md as BASE-2026-09-07-001/002). Found
+something genuinely useful: raising `target_block_size` from 30 to 100 made
+DBLP-ACM's recall ceiling *worse* (0.83 -> 0.53) -- FAISS IVF clustering
+isn't a monotonic refinement across target sizes, so block size can't be
+tuned by intuition. Kept target_block_size=30 (project default, and
+empirically the better of what I measured) for GEPA work.
+
+**Note found, not acted on**: `config.yml`'s `benchmarks.datasets` lists
+`walmart-amazon` and `amazon-google` with Wisconsin DeepMatcher URLs, but
+`serf/eval/benchmarks.py`'s actual `DATASET_REGISTRY` (Leipzig-format URLs)
+only implements `dblp-acm`, `dblp-scholar`, `abt-buy` -- `BENCHMARK_DATASETS`
+in the CLI already reflects this (3 datasets only). Per the plan doc's own
+decision #5 ("adapt so long as you document it"), working with the 3
+datasets that are actually downloadable; walmart-amazon is not available
+without adding DeepMatcher-format loading to `benchmarks.py`, which is a
+separate, undertaken-if-time-permits follow-up, not a GEPA blocker.
+DBLP-Scholar baselines deferred for the same reason (large dataset, and
+GEPA is the higher-priority use of remaining time).
+
+Moving to Task 4 (the core ask): GEPA optimization.
 
 ## Lessons
 

--- a/config.yml
+++ b/config.yml
@@ -36,6 +36,14 @@ er:
     edges: "data/iteration_{iteration}/edges"
     metrics: "data/iteration_{iteration}/metrics"
 
+budget:
+  # Hard, persistent spend caps (docs/SERF_LONG_SHOT_PLAN.md Section 9.6).
+  # Ledgers live in data/budget/<name>.json and survive process restarts.
+  gemini:
+    cap_usd: 100.0
+  gpt_oss_120b_maas:
+    cap_usd: 20.0
+
 mlflow:
   tracking_uri: "http://127.0.0.1:5001"
   experiment_name: "SERF-Entity-Resolution"

--- a/config.yml
+++ b/config.yml
@@ -20,6 +20,7 @@ er:
     batch_size: 10
     max_concurrent: 20
     temperature: 0.0
+    max_output_tokens: 65536
     max_retries: 3
     retry_delay_ms: 300
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -1,0 +1,135 @@
+# SERF Coding Standards
+
+> **The standard: write the simplest code that satisfies the specific requirement in front of you, and nothing else. A researcher should be able to read any SERF module top to bottom, in one sitting, and understand exactly what it does.**
+
+SERF is a research project that we want people to adopt, read, and build on. Research code that nobody can read gets reimplemented instead of cited. Every line we add is a line a reader has to get through before they reach the idea. Treat reader attention as the scarcest resource in the project.
+
+This document covers _how we decide what to write_. For mechanical conventions — formatter, import style, logging, config — see [CLAUDE.md](../CLAUDE.md), which remains authoritative on those.
+
+---
+
+## The Rule
+
+**Implement the requirement. Not the requirement plus the three things you imagine might be asked for next.**
+
+When you find yourself writing code for a case nobody asked about, stop and delete it. If the case turns out to matter, we will add it then, with a test that shows why. Speculative generality is the main way research codebases become unreadable, and it is not free: every branch is a branch the reader must hold in their head and the maintainer must keep correct.
+
+### What this Rules Out
+
+**Defensive checks for conditions that cannot happen.** If a function is only ever called with a non-empty block, do not check for an empty block. If the pipeline guarantees a column exists, do not check whether it exists. Let it fail loudly at the real boundary instead of failing quietly in ten places.
+
+```python
+# No — three branches, two of which never execute
+def resolve(block: EntityBlock | None) -> BlockResolution:
+    if block is None:
+        return BlockResolution(...)
+    if not block.entities:
+        return BlockResolution(...)
+    if len(block.entities) == 1:
+        return BlockResolution(...)
+    ...
+
+# Yes — the caller guarantees a non-empty block; singletons are handled by the caller,
+# where the skip reason belongs
+def resolve(block: EntityBlock) -> BlockResolution:
+    ...
+```
+
+**Configuration for things that have one value.** A parameter that is never passed anything but its default is not a parameter, it is a constant with extra steps. Add the knob when the second caller appears.
+
+**Abstraction with one implementation.** No base classes, protocols, registries, or factories until there are at least two concrete things to abstract over. One `Blocker` class is a class. One `AbstractBlocker` with one `SemanticBlocker` subclass is a class and a riddle.
+
+**Don't create unecessary clases**. Try to use `dicts` for configuration, or anywhere else you can.
+
+**Wrappers that only forward.** If a function's body is a single call to another function with the same arguments, delete it and call the other function.
+
+`try`**/**`except ImportError`**.** Assume dependencies are installed. If they are not, the crash is correct and the traceback is the error message.
+
+**Limit comments intended for yourself.** Do not write many lines of comments for one property when one will do for a human.
+
+### What is Not Ruled Out
+
+Minimalism is about removing incidental complexity, never about removing correctness. These stay:
+
+- **The identifier conservation logic.** It is intricate because the problem is intricate. See [ID_INVARIANTS.md](ID_INVARIANTS.md). Every branch there earns its place and is covered by a test that names the case it protects.
+- **Error recovery around LLM calls.** The network fails and models return malformed output. That is a real case, not a hypothetical one.
+- **Docstrings on public functions.** NumPy style, with types. Reading is the point.
+- **Tests.** Minimal code is not untested code. A small module with a thorough test file is exactly what we want.
+
+---
+
+## Functions
+
+**Aim for one screen.** If a function does not fit in about forty lines, it is usually doing two things. The fix is almost always to name the second thing, not to add comments explaining where it starts.
+
+**One reason to exist.** A function that loads data _and_ transforms it _and_ writes it has three reasons to change. Split it — _except in Spark dataflows_, where the opposite rule applies (see below).
+
+**Return early.** Guard clauses at the top beat nested conditionals in the middle. Prefer three early returns over three levels of indentation.
+
+**Name for what it produces, not how.** `resolve_block` beats `process_block_via_llm_call`. The reader wants to know what they get, not how you got it.
+
+## Spark is different, deliberately
+
+Spark dataflows are the one place where we prefer one long linear function over several small ones. A dataflow broken into `load_x`, `compute_y`, `join_z` forces the reader to jump around to reconstruct a sequence that was linear to begin with, and it obscures the shuffle boundaries that actually determine performance.
+
+Write the dataflow top to bottom in one function. Assume columns exist. Assume paths exist. Do not handle edge cases nobody asked about. This is the rule in [assets/PYSPARK.md](../assets/PYSPARK.md) and it wins over the general "small functions" guidance whenever the two conflict.
+
+## Comments
+
+**Comment the constraint, not the code.** The code says what it does. A comment earns its place only by saying something the code cannot: a non-obvious invariant, a protocol requirement, a counterintuitive reason for an ordering.
+
+```python
+# No — restates the line below it
+# Increment the iteration counter
+iteration += 1
+
+# Yes — states a constraint the reader cannot see
+# The master must be the lowest input id: downstream evaluation joins on it
+# and Abzu's cross-iteration UUID validation assumes this ordering.
+master_id = min(entity_ids)
+```
+
+Never write a comment addressed to the reviewer rather than the reader. No "changed this to fix X", no "as requested", no "this is now correct". Those are pull-request conversation, and they are noise from the moment the PR merges.
+
+## Types
+
+Annotate everything. Modern builtin generics (`list[str]`, `dict[str, int]`), `Optional` from `typing` for optional parameters. Annotations are for the reader first: a signature that states its types is documentation that cannot go stale.
+
+There is currently no type checker wired into the project. Annotations are still required; they are just not machine-verified right now.
+
+## Tests
+
+**Test the behavior, not the implementation.** A test that breaks when you rename a private method is a test that costs more than it protects.
+
+**Name the case in the test name.** `test_recovers_entity_dropped_by_llm` tells a reader what invariant is at stake. `test_unmap_block_2` does not.
+
+**Every invariant in** [ID_INVARIANTS.md](ID_INVARIANTS.md) **has a test that would fail if the invariant broke.** This is the one area where we are deliberately thorough rather than minimal.
+
+**Mock the LLM in unit tests.** Real API calls belong in integration tests, marked, and skipped when no key is present.
+
+pytest style — module-level functions, fixtures for setup. No test classes.
+
+## The CLI
+
+Every capability is reachable from `serf`. If you build something that cannot be run from the command line, it cannot be reproduced, and if it cannot be reproduced it cannot go in the paper.
+
+Logic lives in `serf.<module>`. The CLI in `serf.cli` reads arguments, calls one function, and prints the result. When you catch yourself writing business logic inside a Click command, move it.
+
+## Before you commit
+
+```bash
+uv run ruff check --fix src tests && uv run ruff format src tests
+uv run pytest tests/
+```
+
+Fix both without being asked.
+
+---
+
+## The review question
+
+For every module, function, and branch you add, one question:
+
+> **Would a researcher reading this for the first time understand why it is here?**
+
+If the answer is no, the code is wrong even if it works. Delete it, simplify it, or explain the constraint in one line.

--- a/docs/ID_INVARIANTS.md
+++ b/docs/ID_INVARIANTS.md
@@ -1,0 +1,201 @@
+# Identifier Conservation: The SERF Match/Merge Contract
+
+> **Every integer identifier that enters a block must be accounted for on the way out — either as the identifier of an output record, or inside the merge list of exactly one output record. Nothing is dropped. Nothing is merged into a record the model did not explicitly say it belonged to.**
+
+This is the correctness backbone of the system. A resolution run that violates it is a failed run.
+
+The semantics below were established in the predecessor system, **Abzu** (`/Users/rjurney/Software/weave`), where getting them right was the single hardest part of the work. They are reproduced here as a specification so that SERF can implement them faithfully. The implementation may be improved — cleaner, better tested, better named. **The semantics may not be changed.**
+
+Reference implementation: `abzu/er/uuid.py` (`process_block_with_uuid_mapping`, ~574 lines) and `abzu/er/match.py`. Current SERF implementation: `src/serf/match/uuid_mapper.py` and `src/serf/match/matcher.py`. Section 8 lists every place they currently diverge.
+
+---
+
+## 1. Why identifiers get swapped at all
+
+Language models are measurably worse at manipulating UUIDs than small integers. A UUID is ~36 characters of high-entropy text; a block of 100 records carrying UUIDs plus accumulated provenance can spend more context on identifiers than on the data being matched, and the model transcribes them wrong.
+
+So the pipeline runs an **identifier swapper**: before the LLM call, every record's stable identifier is replaced with a small consecutive integer local to that block. After the call, the integers are swapped back. The model only ever sees integers.
+
+**Integers in, integers out.** This is the contract at every boundary of the matching stage, regardless of what the source dataset uses for keys.
+
+## 2. The four sets
+
+Everything follows from keeping four sets straight. Get these right and the rest is bookkeeping.
+
+| Set | Definition |
+| --- | --- |
+| **Input universe** | Every identifier that enters the block. Critically, this is _not_ just the record identifiers — it also includes every identifier already sitting in an incoming record's `source_ids` from a previous round. |
+| **Output identifiers** | Identifiers appearing in the `source_ids` merge lists of the records the LLM returned. |
+| **Master identifiers** | The top-level identifier of each returned record. Under the MDM convention (§3) a master's own identifier is _not_ in its own `source_ids`, so masters must be counted separately or every master looks missing. |
+| **Missing** | `input_universe − (output_identifiers ∪ master_identifiers)`. |
+
+The input universe is where implementations most often go wrong. On iteration 2 and later, an incoming record already carries the identifiers it absorbed in iteration 1. If those are not in the input universe, a model that drops the record takes its whole merge history with it, silently, and coverage validation will not catch it because it was never counted as present.
+
+Abzu builds the universe from both sources:
+
+```python
+# abzu/er/uuid.py:186-203
+all_input_uuids: set[str] = set()
+...
+    if "uuid" in comp_data and comp_data["uuid"]:
+        input_companies_by_uuid[comp_data["uuid"]] = comp_data
+        all_input_uuids.add(comp_data["uuid"])
+    ...
+    if "source_uuids" in comp_data and isinstance(comp_data["source_uuids"], list):
+        for source_uuid in comp_data["source_uuids"]:
+            if source_uuid:
+                all_input_uuids.add(source_uuid)
+                source_uuid_to_company[source_uuid] = comp_data
+```
+
+## 3. The MDM master-record convention
+
+When the model merges a group of records:
+
+- The record with the **lowest input integer identifier** becomes the master.
+- **All other identifiers in the group** go into the master's `source_ids`.
+- The master's own identifier is **not** in its own `source_ids`.
+- `source_ids` accumulate transitively: if record 1 arrives carrying `source_ids=[3, 7]` and record 22 arrives carrying `source_ids=[2, 4]`, and the model merges them, the output is master `id=1` with `source_ids=[22, 3, 7, 2, 4]`.
+
+That last example is the canonical few-shot demonstration and it is worth keeping verbatim, because transitive accumulation is the part models get wrong.
+
+Downstream evaluation joins on the master identifier and assumes the lowest-id convention. Changing it breaks cross-iteration validation.
+
+## 4. Strip before the call, restore after
+
+Provenance is expensive to send and the model does not need it to make a decision. After many rounds a single record can carry hundreds of accumulated identifiers.
+
+**Stripped before the call**, held in a local cache keyed by mapped integer:
+
+- the stable identifier (UUID or equivalent)
+- `source_ids` — **must be cleared, not just the UUIDs**
+- `source_uuids`
+- `match_skip`, `match_skip_history`
+
+Clearing `source_ids` is not optional and is not merely an optimization. The mapped integers are block-local, in the range assigned by the swapper. If a record arrives already carrying `source_ids=[3, 7]` from a previous round and those are left in place, they occupy the same numeric space as the block-local mapped integers, and the unmapping step will resolve them against the wrong records. This is a silent data-corruption bug that only appears from iteration 2 onward.
+
+**Restored after the call**, from the cache: original identifiers, and the union of every merged record's cached provenance, deduplicated, with the master's own identifier removed.
+
+## 5. Two-phase recovery
+
+After the model returns and provenance is restored, compute the missing set (§2). If it is empty, done. If not, every missing identifier falls into one of two cases and each gets its own phase.
+
+### Phase 1 — patch provenance onto records that survived
+
+A missing identifier was carried in the `source_ids` of an incoming record, and **that record's parent is present in the output.** The model returned the record but dropped part of its merge history. Nothing needs to be re-emitted; the provenance just needs to be put back.
+
+```python
+# abzu/er/uuid.py:493-507 — Step 1: Add back missing UUIDs to existing output companies
+for resolved_company in resolved_companies:
+    company_source_uuids = resolved_company.get("source_uuids") or []
+    for source_uuid in company_source_uuids:
+        if source_uuid in uuids_to_add_back:
+            for uuid_to_add in uuids_to_add_back[source_uuid]:
+                if uuid_to_add not in company_source_uuids:
+                    company_source_uuids.append(uuid_to_add)
+    if company_source_uuids:
+        resolved_company["source_uuids"] = sorted(list(set(company_source_uuids)))
+```
+
+If the _parent_ is also missing, this is not a Phase 1 case — the parent is promoted into Phase 2 and recovering the parent recovers its children with it.
+
+### Phase 2 — re-emit records the model dropped entirely
+
+A missing identifier belonged to a record the model simply did not return. The record is restored from the input cache and re-emitted as a standalone, unmerged record.
+
+```python
+# abzu/er/uuid.py:509-543 — Step 2: Recover entire companies that are missing
+for company_uuid in companies_to_recover:
+    if company_uuid in input_companies_by_uuid:
+        missing_company = copy.deepcopy(input_companies_by_uuid[company_uuid])
+
+        # IMPORTANT: Remove any integer IDs from previous iterations
+        missing_company.pop("id", None)
+        missing_company.pop("source_ids", None)
+
+        # Ensure source_uuids contains the company's own UUID
+        if "source_uuids" not in missing_company or not missing_company["source_uuids"]:
+            missing_company["source_uuids"] = [company_uuid]
+        elif company_uuid not in missing_company["source_uuids"]:
+            missing_company["source_uuids"].append(company_uuid)
+
+        missing_company["match_skip"] = True
+        missing_company["match_skip_reason"] = "missing_in_match_output"
+
+        skip_history = missing_company.get("match_skip_history", []) or []
+        if iteration not in skip_history:
+            skip_history.append(iteration)
+        missing_company["match_skip_history"] = skip_history
+
+        resolved_companies.append(missing_company)
+```
+
+Three details in there are load-bearing:
+
+1. **Stale integer identifiers are dropped** (`pop("id")`, `pop("source_ids")`) so the recovered record cannot collide with the next round's block-local numbering.
+2. **The record's own identifier is forced into its own provenance list.** A recovered record is not a master of a merge, so the MDM exception in §3 does not apply, and coverage validation counts provenance lists.
+3. **The iteration number is appended to** `match_skip_history`, giving per-record skip frequency across rounds. A record skipped in five consecutive rounds is a signal about the blocking, not about the model.
+
+### The rule behind both phases
+
+A dropped record is **never** assumed to have been merged into something. Absence from the output is absence of evidence, not evidence of a match. The system re-emits it unmerged and marks why. This is what makes it safe to run at block sizes where the model measurably drops records.
+
+## 6. Skip reasons
+
+`match_skip_reason` is the audit trail. Every record that did not go through a normal LLM merge carries one.
+
+| Value | Set where | Meaning |
+| --- | --- | --- |
+| `singleton_block` | Match orchestration, before any LLM call | The block had one record. Nothing to match against. Passed through untouched. |
+| `error_recovery` | Match orchestration, on exception | The LLM call failed. All input records passed through unchanged. |
+| `missing_in_match_output` | Phase 2 recovery | The LLM dropped this record. Restored from cache, unmerged. |
+| `missing_primary_uuid` | Evaluation only — a counter, never written to a record | A record identifier went missing. |
+| `missing_source_uuid` | Evaluation only — a counter, never written to a record | A provenance identifier went missing. |
+
+The distinction in the last two matters: they are diagnostics computed during evaluation, not states a record can be in. Do not write them onto records.
+
+**Singletons must be short-circuited before the LLM.** A block of one has no possible match. Sending it costs money, adds a chance for the model to mangle it, and pollutes the results. Abzu splits singleton blocks out at the DataFrame level (`block_size == 1`) and never calls the model on them.
+
+## 7. New identifiers on merged output
+
+When a block is genuinely resolved (`was_resolved == True`), **every** output record from that block gets a freshly generated stable identifier, including Phase 2 recoveries. This makes round _N_ output distinguishable from round _N−1_ input, which is what allows cross-round validation to detect a pipeline that accidentally re-emits its own input.
+
+```python
+# abzu/er/match.py:52-58
+if result.get("was_resolved") and "resolved_companies" in result:
+    for company in result["resolved_companies"]:
+        company["uuid"] = str(uuid.uuid4())
+```
+
+Singleton blocks and error-recovered blocks have `was_resolved == False` and **keep their original identifiers.** They did not change, so they do not get a new identity. Assigning new identifiers unconditionally destroys that signal.
+
+## 8. Where SERF currently diverges
+
+Audited against `src/serf/match/uuid_mapper.py` and `src/serf/match/matcher.py`. Each of these is a task in [.cursor/scratchpad.md](../.cursor/scratchpad.md) (Milestone 1).
+
+| # | Divergence | Consequence | Severity |
+| --- | --- | --- | --- |
+| D1 | `source_ids` are **not** stripped before the LLM call (`uuid_mapper.py:57-60` clears `uuid` and `source_uuids` only) | Pre-existing identifiers from earlier rounds collide with block-local mapped integers; unmapping resolves them against the wrong records | **Corruption, iteration ≥ 2** |
+| D2 | Input universe is only `_int_to_original.keys()` (`uuid_mapper.py:98`) — it excludes provenance carried in on incoming records | Dropped merge history is invisible to the missing-set computation; coverage validation cannot detect it | **Silent loss** |
+| D3 | Only Phase 2 is implemented. There is no `uuids_to_add_back` map and no Phase 1 | Records that survive with truncated provenance are never repaired | **Silent loss** |
+| D4 | `singleton_block` is never set; singleton blocks are sent to the LLM | Wasted spend, unnecessary exposure to model error, skip analysis undercounts | High |
+| D5 | `_assign_uuids` (`matcher.py:178-180`) assigns new identifiers to **all** output including error-recovery pass-throughs | Round _N_ output is indistinguishable from unchanged input; overlap checks lose their meaning | High |
+| D6 | Mapped integers start at 0 (`uuid_mapper.py:46-47`); Abzu starts at 1 | Models conflate `0` with null/absent in structured output | Medium |
+| D7 | `config.yml` declares `er.matching.max_retries` and `retry_delay_ms`; the matcher implements neither | A transient API failure becomes a whole block of `error_recovery` records | Medium |
+| D8 | `config.yml` declares `er.blocking.min_block_size`; nothing reads it | Dead configuration | Low |
+
+D1, D2 and D3 are the ones that can lose data. They are the first thing to fix, and each needs a test that fails against the current implementation before the fix lands.
+
+## 9. Required tests
+
+One test per invariant, named for the invariant. These are the tests that must fail if someone breaks the contract.
+
+1. **Round trip.** Every input identifier appears exactly once in the output, as a master or in exactly one merge list.
+2. **Dropped record.** A mock LLM omits a record entirely. It comes back with `match_skip_reason == "missing_in_match_output"`, its original field values, and its own identifier in its provenance list.
+3. **Dropped provenance, surviving parent.** A mock LLM returns a record but truncates its `source_ids`. Phase 1 restores the missing entries. (Fails today — D3.)
+4. **Second round.** A record carrying `source_ids` from round 1 goes through round 2. Its round-1 provenance survives, and none of those identifiers is resolved against a block-local record. (Fails today — D1, D2.)
+5. **Transitive accumulation.** Master `id=1` `source_ids=[3, 7]` merged with `id=22` `source_ids=[2, 4]` yields master `id=1` with `source_ids == [22, 3, 7, 2, 4]` as a set, and `1` is not in its own list.
+6. **Singleton short-circuit.** A block of one produces no LLM call and one output record with `match_skip_reason == "singleton_block"` and its original identifier. (Fails today — D4.)
+7. **Error recovery.** The LLM raises. All input records come back unchanged with `match_skip_reason == "error_recovery"`, `was_resolved == False`, and **original** identifiers. (Partially fails today — D5.)
+8. **Skip history accumulates.** A record skipped in rounds 1, 2 and 3 ends with `match_skip_history == [1, 2, 3]`.
+9. **Validation gates.** A synthetic run that drops 1% of records fails the coverage gate; a clean run passes all four checks.

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -1,0 +1,99 @@
+# MISSION
+
+**SERF is a research project whose goal is a state-of-the-art system for semantic entity resolution and canonicalization — match and merge — that operates on large groups of records at once rather than on pairs, and that proves its claims on the standard benchmarks.**
+
+The primary deliverable is an academic paper. The secondary deliverable is a small, readable open-source codebase that other researchers actually adopt. Both matter. Neither is optional.
+
+---
+
+## 1. What We Claim
+
+Entity resolution research has converged on a pairwise formulation: take two records, decide whether they match, repeat. Every headline number on Amazon-Google, Walmart-Amazon, Abt-Buy, DBLP-ACM and DBLP-Scholar is a binary classification score over a pre-labeled candidate pair set. Canonicalization was treated as a separate problem than entity resolution. That formulation is an artifact of the tools available when the benchmarks were built, and it is the wrong shape for large language models. Master data management has evolved.
+
+SERF makes four claims:
+
+1. **Set-level beats pairwise.** An LLM shown an entire block of records at once resolves them more accurately than the same LLM shown each pair in isolation, because it can triangulate across the block: if A matches B and B matches C, it sees that A matches C without being asked.
+2. **Set-level is what makes LLM entity resolution economically possible.** One call per block of _N_ records instead of one call per `N(N-1)/2` pairs is the difference between a research prototype and production. The cost reduction is quadratic in block size.
+3. **Resolution and canonicalization should happen in the same call.** Deciding that records match and deciding what the merged golden record should say are the same reasoning problem. Splitting them into two systems throws away information and doubles the cost.
+4. **Prompts should be optimized, not written.** We use GEPA to evolve the instructions and DSPy Flex to move work out of the model and into deterministic code. We do not hand-tune prompts, and we report what the optimizer found.
+
+## 2. Canonicalization, and "match and merge"
+
+**Canonicalization** is the process of collapsing a set of records that refer to the same real-world entity into a single authoritative record — choosing the best value for each field, preserving provenance, and emitting one row where there were many. In master data management this output is called a _golden record_.
+
+**We use the term "canonicalization" because it is correct, but we also say "match and merge" immediately because that is what people understand.** Every abstract, README, and talk should do both at some point. This is a deliberate rhetorical choice, not sloppiness.
+
+The literature gap here is real and it is ours to take. Entity _matching_ with LLMs is a crowded field. Entity _canonicalization_ with LLMs, evaluated on a benchmark, appears to be unclaimed.
+
+## 3. The Scaling Argument
+
+The reason this approach scales is compounding reduction, not raw throughput.
+
+Take a block of 100 records and emit 10. That is 10:1. Re-block the survivors and do it again: 10,000 original records have become 100. Again: 1,000,000 have become 100. Each round is cheaper than the last because the dataset is smaller. The number of LLM calls per round falls geometrically, and the number of rounds needed grows only logarithmically in the size of the input.
+
+This is the core scaling claim of the paper and it must be measured, not asserted. See [RESEARCH_LOOP.md](RESEARCH_LOOP.md), Experiment E3.
+
+## 4. The Hard Constraint
+
+A model can only hold so many records in working memory before it starts dropping them. Somewhere above some block size N — which we must measure per model, the model begins silently omitting input records from its output.
+
+Silently losing records is unacceptable in entity resolution. A resolution system that drops rows is not a resolution system.
+
+Therefore SERF enforces a hard invariant:
+
+> **Identifier conservation.** For every integer identifier that enters a block, that identifier must appear on the way out — either as the identifier of an output record, or inside the merge list (`source_ids`) of an output record. Nothing is silently dropped, and nothing is silently merged into a record the model did not explicitly say it belonged to.
+
+The recovery machinery that enforces this was the hardest part of the predecessor system (Abzu) and its semantics are subtle. They are specified precisely in [ID_INVARIANTS.md](ID_INVARIANTS.md) and must be reproduced exactly. Improving the implementation is welcome; changing the semantics is not.
+
+The relationship between block size, records lost, and recovery cost is not a bug to be hidden. It is a **primary experimental result** of the paper. We measure the loss curve, we publish it, and we show that recovery makes the system safe at block sizes where a naive system would be unsound.
+
+## 5. How We Get to State of the Art
+
+The loop, in Karpathy's framing: build the harness first, make the measurement cheap and trustworthy, then iterate against it until the number goes up. Details in [RESEARCH_LOOP.md](RESEARCH_LOOP.md).
+
+1. **Harness.** Every benchmark loads into one canonical internal format, runs through one pipeline, and reports one set of metrics. Changing datasets changes nothing about the code path.
+2. **Signatures.** DSPy signatures encode the rules that must always hold — the output contract, the master-record convention, the provenance requirements. These are written by hand, informed by the papers that introduced each dataset and by exploratory data analysis of the actual records. This is the core of ER / MDM product management, and it can't be completely automated.
+3. **GEPA.** The optimizer evolves the instruction text against a metric on held-out data. We do not write prompts.
+4. **Flex.** Once quality is there, the optimizer rewrites the module _code_ to answer the easy cases in deterministic Python and reserve the model for genuine ambiguity. The metric penalizes LLM calls, so cost falls without accuracy falling.
+5. **Student-teacher.** Optimize against Gemini, then transfer to `gpt-oss-120b` and `gpt-oss-20b` on Vertex AI. The claim to test is that a well-optimized prompt lets a much cheaper open model close most of the gap.
+
+## 6. What "state of the art" Means
+
+It does not mean "a big number." The entity resolution literature uses at least five mutually incomparable evaluation protocols, and papers routinely quote each other's scores across them.
+
+The bar is:
+
+- We report **which protocol** every number was produced under, always.
+- We beat the best published open model **under the same protocol**, on Amazon-Google, Walmart-Amazon, Abt-Buy, DBLP-ACM and DBLP-Scholar.
+- We additionally report the **clustering / full-table** setting — pairwise F1 over the transitive closure, cluster F1, and B-cubed — because that is the setting our system actually operates in and the pairwise setting flatters everyone.
+- We publish cost per thousand records alongside every F1. A score that costs 100x more than the baseline is a different result than the same score at parity.
+
+Current SERF baseline, for reference, on its own blocked-candidate protocol with `gemini-3.8-flash`: DBLP-ACM F1 0.849, Abt-Buy F1 0.844, DBLP-Scholar F1 0.671. These are the numbers we are trying to beat first. Precision is now 0.99 on two of three datasets; recall (0.57–0.74) is the binding constraint. They are not competitive yet, and saying so plainly is part of the method.
+
+Note that a false positive merge is more damaging than a false negative merge - we must avoid these at all costs and our metrics should work accordingly. We must be relatively conservative about merging records that do not in fact match as it is an inherently destructive act, even though we track provenance.
+
+## 7. Non-Negotiables
+
+- **Embeddings are for blocking only.** Every match decision goes through an LLM. No cosine similarity thresholds, ever. This is what makes the system _semantic_ rather than a reimplementation of 2021.
+- **Identifier conservation holds, always.** A run that violates it is a failed run, not a run with a caveat.
+- **Every number is reproducible from one command.** If a result cannot be regenerated by a CLI invocation recorded in the experiment log, it does not go in the paper.
+- **The code stays small and readable.** A researcher should be able to read a SERF module top to bottom and understand it. See [CODING_STANDARDS.md](CODING_STANDARDS.md). Boilerplate, defensive layers, and speculative abstraction are how research code becomes unreadable and unadopted.
+- **We do not invent numbers.** If a comparison figure cannot be traced to a specific table in a specific paper, it is marked as unverified or it is omitted.
+
+## 8. The Paper
+
+**Title:** _Semantic Entity Resolution and Canonicalization for Agent Memory_
+
+The framing beyond benchmarks: agents accumulate memory, and memory accumulates duplicates. An agent that has met "Acme Corp", "Acme Corporation", and "ACME Inc." across three sessions has three memories of one entity, and every downstream retrieval is degraded by that fragmentation. Entity resolution and canonicalization are the maintenance function that keeps agent memory coherent over time — and it has to run continuously, at low cost, on records nobody labeled.
+
+Draft lives in [paper/](../paper/). It builds to PDF with `../paper/build.sh`.
+
+---
+
+## Reading order for a new contributor
+
+1. This file.
+2. [CODING_STANDARDS.md](CODING_STANDARDS.md) — how we write code here, and why.
+3. [ID_INVARIANTS.md](ID_INVARIANTS.md) — the identifier conservation semantics.
+4. [RESEARCH_LOOP.md](RESEARCH_LOOP.md) — the experiment protocol.
+5. [.cursor/scratchpad.md](../.cursor/scratchpad.md) — what is being worked on right now.

--- a/docs/RESEARCH_LOOP.md
+++ b/docs/RESEARCH_LOOP.md
@@ -1,0 +1,282 @@
+# The SERF Research Loop
+
+How we get from where we are to a paper. This document defines the iteration loop, the experiment registry, the metrics, and the rules for what counts as a result.
+
+Read [MISSION.md](MISSION.md) first. This is the operational companion to it.
+
+---
+
+## 1. The loop
+
+Karpathy's recipe for training neural networks is a general recipe for empirical research, and it maps onto entity resolution almost unchanged. The ordering is the point: each stage exists to make the next one trustworthy, and skipping ahead produces numbers you cannot defend.
+
+### Stage 0 — Become one with the data
+
+Before writing a signature or a prompt, read the records. Not a summary of the records — the records.
+
+For each benchmark: pull 200 rows at random, plus 100 known-positive pairs and 100 known-negative pairs that a string-similarity baseline gets wrong. Read them. Write down, in prose, what actually distinguishes a match from a non-match _in that dataset_. Abt-Buy product names are truncated differently on each side. DBLP-Scholar has OCR noise and missing venues. Amazon-Google has manufacturer fields that are sometimes the manufacturer and sometimes the reseller.
+
+Then read the paper that introduced the dataset and find out what its authors said the hard cases were. Köpcke, Thor & Rahm (PVLDB 2010) for the Leipzig four; Mudgal et al. (SIGMOD 2018) for the DeepMatcher splits and for Walmart-Amazon.
+
+**Output:** one short EDA note per dataset in `docs/eda/<dataset>.md`, ending with the field semantics and matching rules that should go into the DSPy signature. These notes are the input to Stage 2, and they are also Section 4 of the paper.
+
+This stage is not optional and it is not delegable to the optimizer. GEPA can discover phrasing. It cannot discover that the `manufacturer` column means two different things.ccccccvejlfcnffkgnujtbjnkbbdbbicrvgdntgvgiur
+
+### Stage 1 — End-to-end skeleton and dumb baselines
+
+Get the whole pipeline running on every dataset with the stupidest possible matcher, and get the evaluation harness producing numbers you trust. Nothing else matters until this works.
+
+Baselines to implement and report, all of them, forever:
+
+| Baseline | Why it's in the paper |
+| --- | --- |
+| **Random** at the observed positive rate | Establishes the floor. |
+| **Exact string match** on the name field | Shockingly strong on DBLP-ACM. Publishing it keeps everyone honest. |
+| **Jaccard / TF-IDF cosine over tokens**, threshold tuned on the validation split | The pre-neural baseline every reviewer will ask about. |
+| **Blocking-only recall ceiling** | Pair completeness after blocking. This is the hard upper bound on recall; no matcher can exceed it. Report it next to every recall number. |
+| **Single-record-per-call LLM (pairwise)** | The comparison the whole paper turns on. Same model, same prompt content, one pair per call. |
+
+If the harness cannot produce all of these from one command per dataset, the harness is not done.
+
+### Stage 2 — Overfit
+
+Take one dataset, take a small slice, and drive the metric as high as it will go with no concern for cost or generality. The purpose is to find the ceiling and to prove the pipeline has no capacity bug. If you cannot get near-perfect F1 on fifty hand-picked easy DBLP-ACM blocks with an expensive model, something is broken in the plumbing, not in the method.
+
+### Stage 3 — Regularize and generalize
+
+Now make it work across all five datasets with one configuration. This is where GEPA runs, on training splits only, evaluated on held-out validation splits. Test splits stay sealed.
+
+### Stage 4 — Tune
+
+Sweep the parameters that matter: block size, blocking model, number of rounds, LLM-call penalty λ in the Flex metric. Every sweep is an experiment with a registered ID and a logged command.
+
+### Stage 5 — Squeeze
+
+Student-teacher transfer to the open models, ensembling, and the last few points of F1.
+
+### The inner loop
+
+Within any stage, one change at a time:
+
+> **hypothesis → smallest experiment that could falsify it → run → record → keep or revert**
+
+Write the hypothesis down _before_ the run, in the experiment log. A hypothesis written afterward is a rationalization, and it is how research projects convince themselves of things that are not true.
+
+**Speed is a feature of the loop, not a nicety.** If an iteration takes an hour, you will run five of them. If it takes two minutes, you will run a hundred and you will find things. Budget real effort on: caching LLM responses so re-runs are free, sampling modes that give a signal in under five minutes, and a `--limit` that actually limits.
+
+---
+
+## 2. Metrics
+
+The literature uses at least five mutually incomparable evaluation protocols and papers routinely quote each other's numbers across them. Ditto reports 75.58 F1 on Amazon-Google; Peeters et al. re-run Ditto on a dataset of the same name and report 80.07. Neither is wrong.
+
+**Therefore: every number SERF reports carries its protocol label. No exceptions.**
+
+### Protocols
+
+| Label | Definition | Used by |
+| --- | --- | --- |
+| `deepmatcher` | The 3:1:1 train/valid/test split of the pre-blocked labeled pair set. Binary classification over the full test split. | Ditto, Jellyfish, HierGAT, most supervised work |
+| `peeters-subsample` | Test sets down-sampled to ~1,250 pairs with ≥150 positives. | Peeters, Steiner & Bizer, EDBT 2025 |
+| `blocked-topk` | Blocking retrieves top-_k_ candidates; the system selects among them. | ComEM (Wang et al., COLING 2025) |
+| `full-table` | No labeled pair set. The system sees both tables, blocks them itself, and emits clusters. Scored against the ground-truth mapping. | LLM-CER; **SERF's native setting** |
+| `cross-dataset` | Train on the other _n−1_ datasets, test on the held-out one. | AnyMatch, Unicorn evaluations |
+
+SERF's primary results are `full-table`, because that is the setting the system actually operates in and the only one that exercises canonicalization. We _additionally_ report `deepmatcher` and `peeters-subsample` so that our numbers can be placed against published ones.
+
+### The metric set
+
+Pairwise scores are computed over the transitive closure of the emitted clusters.
+
+- **Pairwise precision / recall / F1** — the default. Biased toward large clusters, since a cluster of size _n_ contributes _n(n−1)/2_ pairs.
+- **Cluster F1** — exact cluster match only. Harsh, and unstable when clusters are large.
+- **B-cubed precision / recall / F1** (Bagga & Baldwin 1998) — per-record, then averaged, so entities are weighted equally rather than pairs. This is the honest one for the full-table setting and it is what the clustering literature expects.
+- **Generalized Merge Distance** (Menestrina, Whang & Garcia-Molina, PVLDB 2010) — an edit distance over cluster splits and merges. Cite this paper when arguing metrics are not interchangeable; its central result is that existing ER measures _rank the same algorithms differently_.
+- **Pair completeness** after blocking — the recall ceiling.
+- **Reduction ratio** after blocking.
+
+### Cost, reported alongside every quality number
+
+- **USD per 1,000 input records**, at the published list price of the model used, price date noted.
+- **LLM calls per 1,000 input records.**
+- **Input and output tokens per 1,000 input records.**
+- **Wall-clock seconds per 1,000 input records**, with the concurrency setting.
+
+A result without a cost figure is incomplete. An F1 that costs 100× the baseline is a different result from the same F1 at parity, and the paper's argument depends on saying so.
+
+### Canonicalization quality
+
+Match quality is well-served by the metrics above. Merge quality is not, and there is no standard metric — which is precisely the gap this paper can fill. Proposed, to be pinned down in E7:
+
+- **Field-level accuracy** against a golden record: for each field of each output cluster, does the emitted value match the reference?
+- **Provenance completeness**: fraction of input records whose identifier is reachable from the output cluster that contains them. This is the identifier conservation invariant expressed as a score, and it should be exactly 1.0.
+- **Hallucinated field rate**: fraction of emitted field values that appear in _no_ input record. This should be zero and will not be.
+
+That last metric is important and cheap to compute. A model asked to merge records will sometimes invent a plausible value. Nobody reports this. We should.
+
+---
+
+## 3. Experiment registry
+
+Every experiment has an ID, a written hypothesis, one command, and a result row. IDs are permanent and are cited from the paper.
+
+### E1 — Block size versus record loss
+
+**The core measurement.** Everything about how the system is configured follows from it.
+
+**Hypothesis.** For a given model there is a block size N* below which record loss is negligible and above which it grows sharply, and that *N is substantially larger than the 9 records that prior work ([LLM-CER](https://arxiv.org/abs/2506.02509)) found optimal. Practitioner experience puts it at 100 for Gemini-class models. Prior work says 9. **One of these is wrong, and finding out which is a publishable result either way.**
+
+**Method.** Sweep block size _N_ ∈ {5, 10, 20, 30, 50, 75, 100, 150, 200, 300} × {`gemini-3.8-flash`, `gemini-3.1-flash-lite`, `gpt-oss-120b`, `gpt-oss-20b`} × 5 datasets × 3 seeds. For each cell record:
+
+**Before running this, fix** `max_tokens`**.** It is hardcoded to 8192 in `matcher.py:73`, and the 2026-09-05 baseline run hit 114 truncations that caused 4,441 records to be dropped and recovered. Output length grows with block size, so an unfixed `max_tokens` makes this experiment measure the output-token ceiling instead of the model's working memory — the two are indistinguishable in the drop-rate metric. Raise it to the model maximum, verify zero truncation warnings, and record truncation count as a separate column so the two failure modes stay apart.
+
+| Quantity | Definition |
+| --- | --- |
+| **Drop rate** | Fraction of input identifiers absent from the output before recovery runs |
+| **Provenance truncation rate** | Fraction of incoming `source_ids` entries dropped from surviving records (the Phase 1 case) |
+| **Recovery rate** | Fraction of drops the two-phase recovery caught. Must be 1.0 |
+| **Quality** | Pairwise F1, cluster F1, B-cubed |
+| **Cost** | USD, calls, tokens per 1,000 records |
+| **Position effect** | Drop rate as a function of the record's ordinal position in the prompt |
+
+That last row tests for the lost-in-the-middle effect. If records in the middle of a large block are dropped preferentially, the mitigation is ordering, not a smaller block.
+
+**Deliverable.** The loss curve figure, and a defensible recommended block size per model. This is a headline figure of the paper.
+
+### E2 — Set-level versus pairwise
+
+**Hypothesis.** At equal model and equal information content, matching a whole block in one call beats matching each pair separately, on both F1 and cost.
+
+**Method.** Same model, same blocked candidate set, same field content. Arm A: one call per block. Arm B: one call per pair within the block. Arm C: the ComEM-style "select from _k_ candidates" formulation, as the strongest published set-based baseline. Report F1 and USD/1k for all three.
+
+**Why it matters.** This is the paper's central claim. The prior evidence is encouraging — ComEM reports set-based selection beating pairwise matching by ~14 mean F1 at roughly a fifth of the cost — but it has not been shown at block sizes of 100, and it has not been shown with canonicalization in the same call.
+
+### E3 — Recursive scaling
+
+**Hypothesis.** Reduction compounds across rounds. Blocking and matching _R_ times at a per-round reduction factor _r_ reduces _N_ records to _N·r^R_, at a total cost that is dominated by the first round and converges as _R_ grows.
+
+**Method.** Run 10, 100, 1,000, 10,000 and 100,000 synthetic-plus-benchmark records to convergence. Per round record: input count, output count, round reduction, cumulative reduction, LLM calls, cost, wall-clock, F1 against ground truth, and all four validation gates from [ID_INVARIANTS.md](ID_INVARIANTS.md) §8.
+
+**Deliverable.** The cost-versus-scale curve, and the empirical _r_ per dataset. This is the section that answers "does this actually scale", and the answer has to be a measurement, not the arithmetic in the mission statement.
+
+**Watch for:** quality drift across rounds. Round 3 operates on records that are themselves merge products. If precision degrades as merges compound, that is an important negative result and it goes in the paper.
+
+### E4 — GEPA optimization
+
+**Hypothesis.** GEPA-evolved instructions beat hand-written ones by a margin larger than the seed-to-seed variance, and the margin is larger for weaker models.
+
+**Method.** Baseline is the hand-written signature from Stage 0. Optimize with `dspy.GEPA` on training splits, `auto="light"` then `"medium"`, reflection model Gemini 2.5 Pro (or the strongest available), evaluated on validation. Test stays sealed until the end. Report the optimization budget in rollouts and dollars — GEPA is sample-efficient but not free.
+
+**Report the evolved prompts verbatim in the appendix.** What the optimizer discovered is a finding, not an implementation detail. Diff them against the hand-written versions and say what changed.
+
+**Position against:** the OpenSanctions Pairs work already applies DSPy MIPROv2 to entity matching and reports "consistent but modest" gains of +0.5 to +1.9 F1. If GEPA on block-level matching does substantially better than that, say why. If it does not, say that too.
+
+### E5 — Flex cost reduction
+
+**Hypothesis.** Letting GEPA rewrite the module _code_ (`dspy.Flex`), with a metric that penalizes LLM calls, moves the easy decisions into deterministic Python and cuts cost substantially at equal or better F1.
+
+**Method.** Metric declares `program_trace` and subtracts `λ · n_calls` from the score. Sweep λ ∈ {0, 0.05, 0.1, 0.2, 0.4}. Report the accuracy-versus-cost Pareto frontier and, critically, **what code the optimizer wrote** — which comparisons it decided to settle in Python.
+
+```python
+LLM_CALL_PENALTY = 0.15
+
+def metric(gold, pred, trace=None, pred_name=None, pred_trace=None, program_trace=None):
+    correct = ...
+    n_calls = len(program_trace) if program_trace else 0
+    score = max(0.0, (1.0 if correct else 0.0) - LLM_CALL_PENALTY * n_calls)
+    fb = f"{'Correct' if correct else 'Wrong'} — used {n_calls} LM call(s). Settle clear cases in Python."
+    return dspy.Prediction(score=score, feedback=fb)
+```
+
+**Precedent.** A published Flex case study on a place-matching task moved 75% of records to deterministic Python and went from 90.4% to 95.0% accuracy while getting 28% cheaper and 40% faster. The rules handled easy cases _better_ than a small model did. If that reproduces on ER benchmarks it is a strong result; if it does not, the reason is interesting.
+
+**Prerequisites.** `dspy.Flex` is not in the installed DSPy 3.1.3 — it requires ≥ 3.3.x — and its sandbox needs Deno on the machine. Both are Milestone 4 setup tasks.
+
+### E6 — Student-teacher transfer to open models
+
+**Hypothesis.** A prompt optimized against Gemini transfers to `gpt-oss-120b` and recovers most of the quality at a fraction of the cost; `gpt-oss-20b` recovers less but may still beat the pairwise Gemini baseline.
+
+**Method.** Four arms: (a) Gemini with a hand-written prompt, (b) Gemini GEPA-optimized, (c) `gpt-oss-120b` with Gemini's optimized prompt transferred directly, (d) `gpt-oss-120b` re-optimized with GEPA against itself. Repeat (c) and (d) for `gpt-oss-20b`. Report F1 and USD/1k for all six.
+
+**Models**, via LiteLLM on Vertex AI Model Garden, verified GA:
+
+| Model | LiteLLM route | Input $/1M | Output $/1M | Context |
+| --- | --- | --- | --- | --- |
+| `gpt-oss-120b` | `vertex_ai/openai/gpt-oss-120b-maas` | 0.15 | 0.60 | 131,072 |
+| `gpt-oss-20b` | `vertex_ai/openai/gpt-oss-20b-maas` | 0.075 | 0.30 | 131,072 |
+
+Both support structured output and function calling; neither supports extended thinking. Requires `vertex_ai_project` and `vertex_ai_location` (`us-central1`, or `global` for the 120B).
+
+**The interesting question** is whether re-optimizing per model (arm d) beats transferring (arm c). If transfer is nearly as good, prompt optimization is a portable asset and that is a useful claim.
+
+### E7 — Canonicalization quality
+
+**The novel contribution.** A literature search found no peer-reviewed work that uses an LLM to synthesize a golden record from a matched cluster and evaluates it against a benchmark. Treat that as promising rather than settled, and re-verify before making a first-to-do-this claim in the paper.
+
+**Method.** Construct golden-record ground truth for a subset of clusters on two datasets — the benchmarks give matches, not merged records, so this has to be built. Two sources: derive it programmatically where the ground truth is unambiguous (identical values across a cluster), and hand- label the rest. Then measure field-level accuracy, provenance completeness, and hallucinated field rate (§2).
+
+**Baselines.** Longest-value-wins, most-common-value-wins (the classic survivorship rules from Bleiholder & Naumann's data fusion taxonomy), and a learned record-fusion approach.
+
+### E8 — Protocol-matched comparison to published results
+
+**Method.** Reproduce the exact test splits of the `deepmatcher` and `peeters-subsample` protocols. Run SERF. Place the numbers in a table next to published figures, each cited to a specific table in a specific paper.
+
+**Rules.** Do not compare across protocols. Do not quote a number we have not traced to source. Mark anything unverified as unverified. Where a published number came from a model that was instruction- tuned on the dataset in question — Jellyfish saw Amazon-Google, DBLP-ACM and DBLP-Scholar during tuning — say so in the table.
+
+---
+
+## 4. The experiment log
+
+`experiments/log.md`, append-only. One entry per run. No entry, no result.
+
+```markdown
+## E1-2026-09-05-001 — block size 100, gemini-2.0-flash, dblp-acm
+
+**Hypothesis.** Drop rate stays under 2% at block size 100 on a bibliographic dataset.
+
+**Command.** uv run serf benchmark --dataset dblp-acm --target-block-size 100 \
+ --model gemini/gemini-3.8-flash --seed 0 --out experiments/runs/E1-...
+
+**Config hash.** a3f9c21 **Code.** 529d6fb **Cost.** projected $0.50 / actual $0.42 — day-to-date $12.30 of $100
+
+**Result.** Drop rate 3.8% (84/2210). Recovery 100%. Pairwise F1 0.781, B-cubed F1 0.744. Drops concentrated in prompt positions 40-70.
+
+**Verdict.** Hypothesis rejected — drop rate is nearly 2x the prediction. The positional concentration suggests lost-in-the-middle rather than a capacity limit. Next: E1-...-002 re-runs at 100 with the block shuffled, to separate position from size.
+```
+
+The **verdict** field is the one that matters and the one that gets skipped. Write it.
+
+## 4a. Budget
+
+**$100 per day, maximum, across all models and all experiments. No rollover.**
+
+Every log entry carries a projected cost before the run and a recorded actual after. The two together are how the estimates get good enough to plan with; an experiment nobody can estimate is not ready to run.
+
+Sweeps get staged to fit. E1 is 600 cells and spans several days, so order the grid to produce a usable answer early — sweep block size on one model and one dataset first, since that alone addresses the 9-versus-100 question, then widen.
+
+Two pieces of infrastructure are load-bearing here and belong before the large sweeps:
+
+- **Cost accounting** (T2.5). SERF records no token counts today, so daily spend is currently unmeasurable and the cap is unenforceable. Nothing large should run until this exists.
+- **Response caching** (T2.6). A cached re-run costs nothing against the day's cap, which effectively multiplies the budget across the many re-runs that iteration demands.
+
+When a run would cross the cap, it waits for tomorrow. Finishing "just one more dataset" is how a daily cap silently becomes a weekly one.
+
+## 5. Reproducibility rules
+
+1. **One command per number.** If a figure in the paper cannot be regenerated by a command recorded in the log, it does not go in the paper.
+2. **Seeds are set and recorded.** LLM temperature is 0. Anything still stochastic gets three seeds and a reported standard deviation.
+3. **Every run records the code commit and a config hash.**
+4. **Raw outputs are kept**, not just the metrics. Reviewers ask for examples, and the failure cases are where the next hypothesis comes from.
+5. **Test splits are sealed** until the final run. Optimization touches training and validation only. Every peek is recorded in the log.
+6. **Storage is Apache Iceberg**, so that round _N_ results are queryable as of a snapshot and iterations can be compared by time travel rather than by directory naming conventions.
+
+## 6. Honesty rules
+
+These are here because they are easy to violate under deadline pressure.
+
+- **Report the negative results.** If set-level does not beat pairwise on Amazon-Google, that goes in the table. A paper that wins on five of five datasets and never says what it lost on is not believed.
+- **Do not tune on test.** Not once.
+- **Report the optimization budget.** GEPA numbers without the rollout count and dollar cost are not comparable to anything.
+- **Report contamination risk.** Benchmarks from 2010 are in every model's pretraining data. We cannot eliminate this, but we can measure it: ask the model to complete a record from memory given only its identifier, and report the rate. If a model can recite DBLP-ACM, its DBLP-ACM score means less, and the honest move is to lean on WDC Products' unseen-entity split.
+- **Say when a number is worse than the baseline.** SERF's current DBLP-Scholar F1 is 0.671 against a published Ditto figure of 0.956 on a different protocol. Those are not comparable, and the correct thing to write is exactly that — not a favorable selection.
+- **Attribute gains honestly.** Swapping `gemini-2.0-flash` for `gemini-3.8-flash` moved F1 by +0.073 to +0.137 with no method change at all. Any future gain has to be reported against a fixed, named model, or it is indistinguishable from having picked a newer one.

--- a/experiments/log.md
+++ b/experiments/log.md
@@ -1,0 +1,96 @@
+# SERF Experiment Log
+
+Append-only. One entry per run. No entry, no result. Format and rules from
+[docs/RESEARCH_LOOP.md](../docs/RESEARCH_LOOP.md) Section 4, adapted for a
+**single, $100-total** budget cap (not the $100/day framing in that doc,
+per explicit instruction for this build effort) tracked in
+`data/budget/gemini.json` and `data/budget/gpt_oss_120b_maas.json`.
+
+---
+
+## BASE-2026-09-07-001 — no-LLM baselines, dblp-acm
+
+**Hypothesis.** Exact-name-match is a strong baseline on DBLP-ACM (bibliographic
+titles are often verbatim-identical across sources); TF-IDF cosine trades some
+precision for higher recall; blocking at the project's default
+`target_block_size=30` retains most, but not all, true pairs.
+
+**Command.**
+
+```
+uv run serf baselines --dataset dblp-acm
+uv run serf baselines --dataset dblp-acm --target-block-size 50
+uv run serf baselines --dataset dblp-acm --target-block-size 100
+```
+
+**Config hash.** N/A (no-LLM, deterministic). **Code.** 80cea52 (D1/D4/D5/D6/D7 fixes
++ budget ledger). **Cost.** $0 (no LLM calls) — Gemini ledger unaffected.
+
+**Result** (2,616 left, 2,294 right, 2,224 ground-truth pairs; `full-table` protocol):
+
+| Baseline | Precision | Recall | F1 |
+| --- | --- | --- | --- |
+| Random (floor) | 0.0004 | 0.0004 | 0.0004 |
+| Exact name match | 0.8854 | 0.8826 | 0.8840 |
+| TF-IDF cosine (threshold=0.5) | 0.6394 | 0.9951 | 0.7785 |
+
+Blocking recall ceiling (pair completeness, no matcher can exceed this):
+
+| target_block_size | blocks | avg size | max size | pair completeness |
+| --- | --- | --- | --- | --- |
+| 30 | 82 | 59.9 | 100 | 0.8291 |
+| 50 | 82 | 59.9 | 100 | 0.8291 |
+| 100 | 72 | 68.2 | 100 | 0.5288 |
+
+**Verdict.** Exact-name-match (F1 0.884) is, as the research loop predicted,
+"shockingly strong" on DBLP-ACM — strong enough that it's a real question
+whether an LLM matcher earns its cost here at all; that comparison belongs in
+the paper. More surprising: **raising `target_block_size` from 30/50 to 100
+made the recall ceiling worse (0.83 -> 0.53), not better.** FAISS `IndexIVFFlat`
+clustering is not a simple refinement across target sizes — a different
+`nlist` produces a qualitatively different partition, and 30 and 50 happened
+to land on the identical partition here (82 blocks either way) while 100 did
+not. This means block size cannot be tuned by intuition ("bigger blocks see
+more candidates") — it must be measured per dataset, which is exactly
+Experiment E1's point. Deferred: a full E1-style sweep (multiple sizes x
+multiple datasets x multiple seeds) is out of scope for this session's time
+budget; used target_block_size=30 (the existing project default, and the
+better of the three measured here) for all GEPA work that follows.
+
+---
+
+## BASE-2026-09-07-002 — no-LLM baselines, abt-buy
+
+**Hypothesis.** Abt-Buy product titles are written independently per retailer
+(not shared catalog copy like bibliographic titles), so exact-name-match
+should do far worse here than on DBLP-ACM; TF-IDF should do better than exact
+match but still leave real headroom for semantic matching.
+
+**Command.** `uv run serf baselines --dataset abt-buy`
+
+**Config hash.** N/A. **Code.** 80cea52. **Cost.** $0.
+
+**Result** (1,076 left, 1,076 right — actual downloaded sizes; 1,097 ground-truth
+pairs; `full-table` protocol):
+
+| Baseline | Precision | Recall | F1 |
+| --- | --- | --- | --- |
+| Random (floor) | 0.0000 | 0.0000 | 0.0000 |
+| Exact name match | 1.0000 | 0.0091 | 0.0181 |
+| TF-IDF cosine (threshold=0.5) | 0.5694 | 0.5123 | 0.5393 |
+| Blocking recall ceiling (target_block_size=30) | -- | 0.8241 | -- |
+
+**Verdict.** Confirmed. Exact-name-match is nearly useless on Abt-Buy (F1
+0.018) — the two retailers essentially never write the identical string for
+the same product — which is the opposite of DBLP-ACM and is exactly the kind
+of domain-dependent behavior the research loop says to expect and report
+side-by-side, not average away. TF-IDF (F1 0.54) leaves substantial headroom
+(1.0 - 0.54 = 0.46) for a semantic matcher to close. Blocking recall ceiling
+(0.82) is close to DBLP-ACM's, suggesting the ~0.83 ceiling at
+target_block_size=30 is not dataset-specific in this case.
+
+---
+
+## GEPA-2026-09-07-001 — GEPA optimization setup, dblp-acm
+
+See below; entry added once the optimization run completes.

--- a/experiments/log.md
+++ b/experiments/log.md
@@ -91,6 +91,97 @@ target_block_size=30 is not dataset-specific in this case.
 
 ---
 
-## GEPA-2026-09-07-001 — GEPA optimization setup, dblp-acm
+## GEPA-2026-09-07-001 — GEPA optimization, dblp-acm (true-pair-only sample)
 
-See below; entry added once the optimization run completes.
+**Hypothesis.** GEPA-evolved instructions beat the hand-written `BlockMatch`
+signature on a sealed test split, per Experiment E4.
+
+**Command.** `uv run python scripts/run_gepa.py dblp-acm 300 light` (student
+`gemini-3.5-flash-lite` @ temperature=0.0, reflection_lm `gemini-3.7-flash`
+@ temperature=1.0, `target_block_size=30`, seed=0)
+
+**Config hash.** N/A (script run, not yet wired to config hashing). **Code.**
+62609e0. **Cost.** ~$18 (dominated by GEPA's `auto="light"` running many
+reflective iterations against a training set that turned out to be trivial
+-- see verdict). Cumulative Gemini spend at completion: ~$18.9 of $100.
+
+**Result.** `baseline_f1 = 1.0`, `optimized_f1 = 1.0`. n_train=6, n_val=3,
+n_test=0 (!) on the first attempt with `sample_size=40` -- degenerate split,
+re-run at `sample_size=300` gave n_train=6, n_val=3, n_test=4, both still 1.0.
+
+**Verdict.** Hypothesis untestable as run: `build_candidate_blocks`'s initial
+sampling strategy (only entities that are members of a known true pair) made
+every block trivially resolvable -- there was no genuine ambiguity, so both
+the hand-written baseline and the optimizer's output scored perfectly and
+GEPA's own log shows "All subsample scores perfect for parent N. Skipping."
+repeated for over 100 iterations. This is itself a useful finding (Stage 1/2
+validation: the base pipeline has no capacity bug on easy DBLP-ACM blocks,
+consistent with RESEARCH_LOOP.md Stage 2's overfitting check), but it means
+this specific run cannot support or refute the E4 hypothesis. Fixed by mixing
+in random distractor entities (commit 62609e0) and moved the next attempt to
+`abt-buy`, where the no-LLM baselines (BASE-2026-09-07-002) already show much
+more headroom (exact-match F1 0.018 vs. DBLP-ACM's 0.884).
+
+**Side findings from this run** (real bugs, fixed, see commit 377b5d5):
+oversized blocks (71, 41 entities against a target of 30) from unsupervised
+clustering on a small sample, and `dspy.XMLAdapter` failing to parse model
+output containing unescaped `&` (~10% of DBLP-ACM's titles/descriptions
+contain one) -- both root-caused with single, minimal-repro diagnostic calls
+before committing further budget to full runs, per this doc's own guidance
+("smallest experiment that could falsify it").
+
+---
+
+## GEPA-2026-09-07-002 — GEPA optimization, abt-buy (with distractors)
+
+**Hypothesis.** With genuine ambiguity in the training blocks (true pairs
+mixed with random distractor entities, not true-pair members only), GEPA's
+evolved instructions beat the hand-written baseline on Abt-Buy's sealed test
+split, where the no-LLM baselines show real headroom.
+
+**Command.** `uv run python scripts/run_gepa.py abt-buy 150 30` (student
+`gemini-3.5-flash-lite` @ temperature=0.0, reflection_lm `gemini-3.7-flash`
+@ temperature=1.0, `target_block_size=30`, `max_metric_calls=30`, seed=0)
+
+**Config hash.** N/A. **Code.** f9313f4. **Cost.** ~$1.35 (cumulative Gemini
+spend: $32.66 of $100, most of the delta from this run's own baseline eval +
+30 metric calls + reflection).
+
+**Result.** `baseline_f1 = 0.95`, `optimized_f1 = 1.00`. n_train=6, n_val=3,
+n_test=4. Elapsed 347.6s. Zero XML-parsing failures (the ampersand and
+block-size fixes held). Optimized instructions saved to
+`data/gepa/abt_buy_optimized_150_30.json`.
+
+The evolved instructions are dramatically more detailed than the hand-written
+original -- they name specific normalization rules (strip hyphens/underscores/
+case in model numbers), specific brand aliases discovered from the training
+data (Eureka/Electrolux, Transcend/TRANSCEND INFORMATION), typo patterns
+(Tvio/TiVo), and explicit false-positive guards (don't merge different
+storage capacities or receiver tiers of the same brand). Full text: see PR
+description / `data/gepa/abt_buy_optimized_150_30.json`.
+
+**Verdict.** Directionally positive and the plumbing worked end-to-end for
+the first time this session, but **this result must be read with its sample
+size, not despite it**: n_test=4 means going from 0.95 to 1.00 could be a
+single corrected example, and n_train=6 is small enough that the optimizer
+plausibly partly *memorized* specific training-set entities (the brand
+aliases and model numbers named in the evolved instructions are exact
+examples from the ~13 candidate blocks built for this run) rather than
+learning principles that generalize to arbitrary unseen Abt-Buy products.
+Per this doc's own honesty rules ("report the optimization budget", "do not
+tune on test"): the test set here is sealed and was not touched during
+optimization, but it is too small to license a strong claim. Treat this run
+as a validated proof that the full loop (gold-label construction -> GEPA ->
+sealed-test evaluation) works correctly and *can* show improvement, not as
+publishable evidence that it reliably does. A follow-up with a substantially
+larger train/val/test split (all bounded by `max_metric_calls` for
+predictable cost/runtime, per the fix in commit 62609e0) is needed before
+reporting a GEPA effect size with any confidence.
+
+**Note on GPT-OSS-120B-maas.** Per explicit instruction, the intended
+configuration for this and subsequent runs is teacher=`gemini-3.5-flash-lite`,
+student=`gpt-oss-120b-maas`, reverting to student=`gemini-3.5-flash-lite`/
+teacher=`gemini-3.7-flash` (as run here) only as a stopgap until Vertex AI
+credentials (`GOOGLE_CLOUD_PROJECT` + Application Default Credentials) are
+available in this environment -- currently only `GEMINI_API_KEY` is
+configured. `gpt_oss_120b_maas` ledger: $0 spent to date.

--- a/experiments/log.md
+++ b/experiments/log.md
@@ -185,3 +185,60 @@ teacher=`gemini-3.7-flash` (as run here) only as a stopgap until Vertex AI
 credentials (`GOOGLE_CLOUD_PROJECT` + Application Default Credentials) are
 available in this environment -- currently only `GEMINI_API_KEY` is
 configured. `gpt_oss_120b_maas` ledger: $0 spent to date.
+
+---
+
+## GEPA-2026-09-08-001 — GEPA optimization, abt-buy (full dataset, all blocks)
+
+**Hypothesis.** A much larger, unfiltered training set (all 98 blocks from
+the full Abt-Buy dataset, not just the 39 containing a labeled true pair)
+gives GEPA a more realistic, harder, and more statistically meaningful signal
+than GEPA-2026-09-07-002's 13-block, distractor-only sample, and the
+optimizer improves on the hand-written baseline here too.
+
+**Command.** `uv run python scripts/run_gepa.py abt-buy full 150 --all-blocks`
+(student `gemini-3.5-flash-lite` @ temperature=0.0, reflection_lm
+`gemini-3.7-flash` @ temperature=1.0, `target_block_size=30`,
+`max_metric_calls=150`, `require_true_pair=False`, seed=0)
+
+**Config hash.** N/A. **Code.** 3985e1a. **Cost.** ~$6.03 (cumulative Gemini
+spend: $40.27 of $100). **Wall clock.** 1832.9s (~30.5 min).
+
+**Result.** `baseline_f1 = optimized_f1 = 0.470097...` (identical to full
+float precision). n_train=49, n_val=24, n_test=25. Zero XML-parsing
+failures across 150+ metric calls plus baseline/final eval on 25 test
+examples each.
+
+Inspecting the saved program confirms the optimizer did not change anything:
+`data/gepa/abt_buy_optimized_None_150.json`'s instructions are byte-identical
+to the original hand-written `BlockMatch` docstring. The log shows this was
+not a silent failure -- GEPA proposed and evaluated at least 6 distinct
+candidate instructions against the validation set (aggregate scores around
+0.21-0.24), but every one scored at or below the original ("Selected program
+0" -- the unmodified baseline -- is the most frequent log line, and multiple
+"New subsample score N is not better than old score N, skipping" entries
+confirm proposed candidates were compared and rejected, not ignored).
+
+**Verdict.** Genuine negative result, reported as such per this doc's own
+honesty rules ("say when a number is worse than the baseline" and "report
+the optimization budget"). Three candidate explanations, none mutually
+exclusive: (1) 150 metric calls may simply be too small a budget for GEPA to
+find an improvement on a 49-example training set with this much
+heterogeneity (98 blocks across the whole dataset vs. 13 curated ones) --
+the prior positive result used a budget-to-trainset-size ratio of 30:6 = 5x,
+this run used 150:49 = 3x; (2) instruction-only optimization (no `dspy.Flex`
+restructuring) may have limited headroom against Gemini 3.5 Flash-Lite's
+intrinsic ceiling on this harder distribution; (3) F1=0.47 itself is
+measured by this module's simplified harness (`dspy.Predict(BlockMatch)`
+called directly with block-local mapped ids, scored by `er_metric`'s
+pairwise F1) rather than the full production path (`EntityMatcher` +
+`UUIDMapper` + `evaluate_er_results`), so it is not directly comparable to
+`serf benchmark`'s reported numbers or to MISSION.md's cited baseline
+(0.844 F1 on Abt-Buy, different model, different harness) -- the drop from
+0.95 (previous run) to 0.47 here is a difficulty/realism change in the
+*evaluation set*, not evidence the pipeline regressed.
+
+**Follow-up, not done this session (time/budget):** re-run with a larger
+`max_metric_calls` (e.g. 400-500) to test whether budget was the binding
+constraint, and/or evaluate the same trainset through the full production
+harness for a directly comparable number.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pandas>=2.0",
     "pyspark-mcp>=0.0.6",
     "mlflow[genai]>=3.10.1",
+    "google-auth>=2.0",
 ]
 
 [project.urls]

--- a/scripts/run_gepa.py
+++ b/scripts/run_gepa.py
@@ -26,10 +26,12 @@ logger = get_logger(__name__)
 def main() -> None:
     setup_logging()
     dataset_name = sys.argv[1] if len(sys.argv) > 1 else "dblp-acm"
-    sample_size = int(sys.argv[2]) if len(sys.argv) > 2 else 300
+    sample_arg = sys.argv[2] if len(sys.argv) > 2 else "300"
+    sample_size = None if sample_arg == "full" else int(sample_arg)
     auto_or_calls = sys.argv[3] if len(sys.argv) > 3 else "light"
     auto = auto_or_calls if auto_or_calls in ("light", "medium", "heavy") else None
     max_metric_calls = None if auto else int(auto_or_calls)
+    require_true_pair = "--all-blocks" not in sys.argv
 
     start = time.time()
     result = run_gepa_optimization(
@@ -40,6 +42,7 @@ def main() -> None:
         target_block_size=30,
         auto=auto,
         max_metric_calls=max_metric_calls,
+        require_true_pair=require_true_pair,
         seed=0,
     )
     elapsed = time.time() - start

--- a/scripts/run_gepa.py
+++ b/scripts/run_gepa.py
@@ -1,7 +1,8 @@
-"""Driver script for a GEPA optimization run against DBLP-ACM.
+"""Driver script for a GEPA optimization run against a benchmark dataset.
 
 Not part of the package: a one-off script for this build session's
-optimization run, invoked directly with `uv run python scripts/run_gepa_dblp_acm.py`.
+optimization runs, invoked directly with
+`uv run python scripts/run_gepa.py <dataset> <sample_size> <auto>`.
 """
 
 # isort: off
@@ -12,6 +13,7 @@ import dspy  # noqa: F401
 
 # isort: on
 import json
+import os
 import sys
 import time
 
@@ -23,17 +25,21 @@ logger = get_logger(__name__)
 
 def main() -> None:
     setup_logging()
-    sample_size = int(sys.argv[1]) if len(sys.argv) > 1 else 300
-    auto = sys.argv[2] if len(sys.argv) > 2 else "light"
+    dataset_name = sys.argv[1] if len(sys.argv) > 1 else "dblp-acm"
+    sample_size = int(sys.argv[2]) if len(sys.argv) > 2 else 300
+    auto_or_calls = sys.argv[3] if len(sys.argv) > 3 else "light"
+    auto = auto_or_calls if auto_or_calls in ("light", "medium", "heavy") else None
+    max_metric_calls = None if auto else int(auto_or_calls)
 
     start = time.time()
     result = run_gepa_optimization(
-        dataset_name="dblp-acm",
+        dataset_name=dataset_name,
         task_model="gemini/gemini-3.5-flash-lite",
         reflection_model="gemini/gemini-3.7-flash",
         sample_size=sample_size,
         target_block_size=30,
         auto=auto,
+        max_metric_calls=max_metric_calls,
         seed=0,
     )
     elapsed = time.time() - start
@@ -42,9 +48,8 @@ def main() -> None:
     print(json.dumps(result, indent=2))
     print(f"Elapsed: {elapsed:.1f}s")
 
-    out_path = f"data/gepa/dblp_acm_optimized_{sample_size}_{auto}.json"
-    import os
-
+    dataset_slug = dataset_name.replace("-", "_")
+    out_path = f"data/gepa/{dataset_slug}_optimized_{sample_size}_{auto_or_calls}.json"
     os.makedirs("data/gepa", exist_ok=True)
     optimized.save(out_path)
     print(f"Saved optimized program to {out_path}")

--- a/scripts/run_gepa_dblp_acm.py
+++ b/scripts/run_gepa_dblp_acm.py
@@ -1,0 +1,53 @@
+"""Driver script for a GEPA optimization run against DBLP-ACM.
+
+Not part of the package: a one-off script for this build session's
+optimization run, invoked directly with `uv run python scripts/run_gepa_dblp_acm.py`.
+"""
+
+# isort: off
+# numpy must load before dspy in a fresh process -- see the matching comment
+# in src/serf/dspy/optimize.py.
+import numpy  # noqa: F401
+import dspy  # noqa: F401
+
+# isort: on
+import json
+import sys
+import time
+
+from serf.dspy.optimize import run_gepa_optimization
+from serf.logs import get_logger
+
+logger = get_logger(__name__)
+
+
+def main() -> None:
+    sample_size = int(sys.argv[1]) if len(sys.argv) > 1 else 60
+    auto = sys.argv[2] if len(sys.argv) > 2 else "light"
+
+    start = time.time()
+    result = run_gepa_optimization(
+        dataset_name="dblp-acm",
+        task_model="gemini/gemini-3.5-flash-lite",
+        reflection_model="gemini/gemini-3.7-flash",
+        sample_size=sample_size,
+        target_block_size=30,
+        auto=auto,
+        seed=0,
+    )
+    elapsed = time.time() - start
+
+    optimized = result.pop("optimized_program")
+    print(json.dumps(result, indent=2))
+    print(f"Elapsed: {elapsed:.1f}s")
+
+    out_path = f"data/gepa/dblp_acm_optimized_{sample_size}_{auto}.json"
+    import os
+
+    os.makedirs("data/gepa", exist_ok=True)
+    optimized.save(out_path)
+    print(f"Saved optimized program to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_gepa_dblp_acm.py
+++ b/scripts/run_gepa_dblp_acm.py
@@ -16,13 +16,14 @@ import sys
 import time
 
 from serf.dspy.optimize import run_gepa_optimization
-from serf.logs import get_logger
+from serf.logs import get_logger, setup_logging
 
 logger = get_logger(__name__)
 
 
 def main() -> None:
-    sample_size = int(sys.argv[1]) if len(sys.argv) > 1 else 60
+    setup_logging()
+    sample_size = int(sys.argv[1]) if len(sys.argv) > 1 else 300
     auto = sys.argv[2] if len(sys.argv) > 2 else "light"
 
     start = time.time()

--- a/src/serf/analyze/profiler.py
+++ b/src/serf/analyze/profiler.py
@@ -132,10 +132,12 @@ def generate_er_config(
         YAML string with the recommended ER configuration
     """
     from serf.config import config as serf_config
+    from serf.dspy.budget import TrackedLM, get_ledger
 
     effective_model = model or serf_config.get("models.analyze_llm")
     api_key = os.environ.get("GEMINI_API_KEY", "")
-    lm = dspy.LM(effective_model, api_key=api_key)
+    ledger_name = "gpt_oss_120b_maas" if "gpt-oss" in effective_model else "gemini"
+    lm = TrackedLM(effective_model, ledger=get_ledger(ledger_name), api_key=api_key)
     logger.info(f"Using LLM model: {effective_model}")
 
     predictor = dspy.ChainOfThought(GenerateERConfig)

--- a/src/serf/analyze/profiler.py
+++ b/src/serf/analyze/profiler.py
@@ -132,6 +132,7 @@ def generate_er_config(
         YAML string with the recommended ER configuration
     """
     from serf.config import config as serf_config
+    from serf.dspy.adapters import RobustXMLAdapter
     from serf.dspy.budget import TrackedLM, get_ledger
 
     effective_model = model or serf_config.get("models.analyze_llm")
@@ -146,7 +147,7 @@ def generate_er_config(
     samples_json = json.dumps(sample_records[:10], indent=2, default=str)
 
     logger.info("Generating ER config with LLM...")
-    with dspy.context(lm=lm, adapter=dspy.XMLAdapter()):
+    with dspy.context(lm=lm, adapter=RobustXMLAdapter()):
         result = predictor(
             dataset_profile=profile_json,
             sample_records=samples_json,

--- a/src/serf/cli/main.py
+++ b/src/serf/cli/main.py
@@ -976,6 +976,107 @@ def benchmark_all(
 
 
 # ---------------------------------------------------------------------------
+# baselines  (no-LLM reference points)
+# ---------------------------------------------------------------------------
+
+
+@cli.command()
+@click.option(
+    "--dataset",
+    "-d",
+    type=click.Choice(BENCHMARK_DATASETS, case_sensitive=False),
+    required=True,
+    help="Benchmark dataset name",
+)
+@click.option(
+    "--target-block-size",
+    type=int,
+    default=30,
+    help="Target entities per block, for the blocking-recall-ceiling baseline",
+)
+@click.option(
+    "--tfidf-threshold",
+    type=float,
+    default=0.5,
+    help="Cosine similarity threshold for the TF-IDF baseline",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    type=click.Path(),
+    default="data/benchmarks",
+    help="Output directory for results",
+)
+def baselines(
+    dataset: str,
+    target_block_size: int,
+    tfidf_threshold: float,
+    output_path: str,
+) -> None:
+    """Run no-LLM baselines for a benchmark dataset.
+
+    Random, exact-name-match, TF-IDF cosine, and the blocking recall
+    ceiling: the floor and the pre-neural reference point every LLM-based
+    `serf benchmark` result should be reported against.
+    """
+    from serf.block.pipeline import SemanticBlockingPipeline
+    from serf.eval.baselines import (
+        exact_name_match_baseline,
+        random_baseline,
+        tfidf_cosine_baseline,
+    )
+    from serf.eval.benchmarks import BenchmarkDataset
+    from serf.eval.metrics import pair_completeness
+
+    click.echo(f"Running baselines: {dataset}")
+    data = BenchmarkDataset.download(dataset)
+    left, right = data.to_entities()
+    true_pairs = data.ground_truth
+    click.echo(f"  {len(left)} left, {len(right)} right, {len(true_pairs)} ground truth pairs")
+
+    click.echo("  Random...")
+    results: dict[str, dict[str, float]] = {"random": random_baseline(left, right, true_pairs)}
+
+    click.echo("  Exact name match...")
+    results["exact_name_match"] = exact_name_match_baseline(left, right, true_pairs)
+
+    click.echo(f"  TF-IDF cosine (threshold={tfidf_threshold})...")
+    results["tfidf_cosine"] = tfidf_cosine_baseline(
+        left, right, true_pairs, threshold=tfidf_threshold
+    )
+
+    click.echo(f"  Blocking recall ceiling (target_block_size={target_block_size})...")
+    pipeline = SemanticBlockingPipeline(target_block_size=target_block_size)
+    blocks, _ = pipeline.run(left + right)
+    blocked_pairs: set[tuple[int, int]] = set()
+    for block in blocks:
+        ids = [e.id for e in block.entities]
+        for i, a in enumerate(ids):
+            for b in ids[i + 1 :]:
+                blocked_pairs.add((min(a, b), max(a, b)))
+    ceiling = pair_completeness(blocked_pairs, true_pairs)
+    results["blocking_recall_ceiling"] = {"pair_completeness": ceiling, "num_blocks": len(blocks)}
+
+    click.echo(f"\n{'=' * 70}")
+    click.echo(f"{'Baseline':<25} {'Precision':>10} {'Recall':>10} {'F1':>10}")
+    click.echo("-" * 70)
+    for name in ("random", "exact_name_match", "tfidf_cosine"):
+        m = results[name]
+        click.echo(
+            f"{name:<25} {m['precision']:>10.4f} {m['recall']:>10.4f} {m['f1_score']:>10.4f}"
+        )
+    click.echo(f"{'blocking_recall_ceiling':<25} {'':>10} {ceiling:>10.4f} {'':>10}")
+    click.echo("=" * 70)
+
+    os.makedirs(output_path, exist_ok=True)
+    out_file = os.path.join(output_path, f"{dataset}_baselines.json")
+    with open(out_file, "w") as f:
+        json.dump(results, f, indent=2)
+    click.echo(f"\nResults saved to {out_file}")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/src/serf/dspy/adapters.py
+++ b/src/serf/dspy/adapters.py
@@ -1,0 +1,46 @@
+"""A hardened dspy.XMLAdapter for real-world text containing XML special characters.
+
+`dspy.XMLAdapter.parse()` uses `xml.etree.ElementTree`, a strict XML parser.
+When an entity's `name`/`description` contains a raw `&` (e.g. "Black &
+White", "Effective & Efficient..." -- roughly 10% of DBLP-ACM's records), the
+model tends to echo it back unescaped, and the response fails to parse as
+XML at all. This is a real, measured cause of prediction failures during
+GEPA optimization, not a hypothetical edge case.
+"""
+
+import re
+
+import dspy
+
+# A bare `&` not already followed by a known XML entity name/numeric
+# reference. Escaping only bare ampersands (not attempting to fix stray
+# `<`/`>`, which are far rarer in this domain and much harder to
+# distinguish from real tags) fixes the overwhelming majority of cases.
+_BARE_AMPERSAND = re.compile(r"&(?!amp;|lt;|gt;|quot;|apos;|#\d+;|#x[0-9a-fA-F]+;)")
+
+
+def escape_bare_ampersands(text: str) -> str:
+    """Escape `&` characters that are not already part of a valid XML entity.
+
+    Parameters
+    ----------
+    text : str
+        Raw text, possibly containing unescaped ampersands
+
+    Returns
+    -------
+    str
+        Text with every bare `&` replaced by `&amp;`
+    """
+    return _BARE_AMPERSAND.sub("&amp;", text)
+
+
+class RobustXMLAdapter(dspy.XMLAdapter):
+    """dspy.XMLAdapter that escapes bare ampersands before parsing.
+
+    Behaves identically to dspy.XMLAdapter in every other respect; this is
+    the minimal, targeted fix for a real failure mode, not a rewrite.
+    """
+
+    def parse(self, signature: type[dspy.Signature], completion: str) -> dict[str, object]:
+        return super().parse(signature, escape_bare_ampersands(completion))

--- a/src/serf/dspy/budget.py
+++ b/src/serf/dspy/budget.py
@@ -1,0 +1,143 @@
+"""Persistent, hard-capped budget ledgers for LLM API spend.
+
+`TrackedLM` wraps `dspy.LM` so that every call's real cost -- computed by
+litellm from the model's list price and the call's actual token usage, and
+zero on a cache hit -- is recorded into a `BudgetLedger`. The ledger is a
+small JSON file, not an in-memory counter, so restarting the process does
+not reset the cap: the whole point of a hard budget guard is that it
+survives crashes and restarts (docs/SERF_LONG_SHOT_PLAN.md Section 9.6).
+"""
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import dspy
+
+from serf.logs import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_LEDGER_DIR = "data/budget"
+
+
+class BudgetExceededError(Exception):
+    """Raised when a ledger's cap has already been reached."""
+
+
+class BudgetLedger:
+    """Tracks one named budget's cumulative USD spend, persisted to disk."""
+
+    def __init__(self, name: str, cap_usd: float, ledger_dir: str = DEFAULT_LEDGER_DIR) -> None:
+        """Initialize (or reattach to) a named, capped, file-backed ledger.
+
+        Parameters
+        ----------
+        name : str
+            Ledger name (e.g. "gemini", "gpt_oss_120b_maas"). One file per name.
+        cap_usd : float
+            Hard spend cap in USD. `check()` raises once cumulative spend >= this.
+        ledger_dir : str
+            Directory holding one JSON file per ledger name.
+        """
+        self.name = name
+        self.cap_usd = cap_usd
+        self._path = Path(ledger_dir) / f"{name}.json"
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        if not self._path.exists():
+            self._write(0.0, 0)
+
+    def _read(self) -> tuple[float, int]:
+        data = json.loads(self._path.read_text())
+        return data["spend_usd"], data["call_count"]
+
+    def _write(self, spend_usd: float, call_count: int) -> None:
+        self._path.write_text(
+            json.dumps({"spend_usd": spend_usd, "call_count": call_count}, indent=2)
+        )
+
+    @property
+    def spend_usd(self) -> float:
+        """Current cumulative spend in USD."""
+        return self._read()[0]
+
+    @property
+    def call_count(self) -> int:
+        """Current cumulative non-cached call count."""
+        return self._read()[1]
+
+    def check(self) -> None:
+        """Raise BudgetExceededError if this ledger's cap is already reached."""
+        spend, _ = self._read()
+        if spend >= self.cap_usd:
+            raise BudgetExceededError(
+                f"{self.name!r} budget exhausted: ${spend:.4f} spent >= ${self.cap_usd:.2f} cap"
+            )
+
+    def record(self, cost_usd: float) -> float:
+        """Record an actual spend (0.0 for cache hits) and return the new total.
+
+        Parameters
+        ----------
+        cost_usd : float
+            Actual USD cost of the call that just completed.
+
+        Returns
+        -------
+        float
+            New cumulative spend after recording.
+        """
+        with self._lock:
+            spend, calls = self._read()
+            spend += cost_usd
+            calls += 1
+            self._write(spend, calls)
+        if spend > self.cap_usd:
+            logger.warning(f"{self.name!r} budget EXCEEDED: ${spend:.4f} > ${self.cap_usd:.2f} cap")
+        return spend
+
+
+def get_ledger(name: str) -> BudgetLedger:
+    """Build the named BudgetLedger using its cap from config.yml `budget.<name>.cap_usd`.
+
+    Parameters
+    ----------
+    name : str
+        Ledger name matching a `budget.<name>` section in config.yml
+
+    Returns
+    -------
+    BudgetLedger
+        Ledger enforcing that section's cap_usd
+    """
+    from serf.config import config
+
+    cap = config.get(f"budget.{name}.cap_usd")
+    return BudgetLedger(name=name, cap_usd=float(cap))
+
+
+class TrackedLM(dspy.LM):
+    """A dspy.LM that records every call's real cost into a BudgetLedger.
+
+    Rejects a call before it happens if the ledger is already at or over
+    its cap; otherwise behaves exactly like dspy.LM. Works for both the
+    sync and async call paths, since both funnel through `update_history`.
+    """
+
+    def __init__(self, *args: Any, ledger: BudgetLedger, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.ledger = ledger
+
+    def update_history(self, entry: dict[str, Any]) -> None:
+        super().update_history(entry)
+        self.ledger.record(entry.get("cost") or 0.0)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.ledger.check()
+        return super().__call__(*args, **kwargs)
+
+    async def acall(self, *args: Any, **kwargs: Any) -> Any:
+        self.ledger.check()
+        return await super().acall(*args, **kwargs)

--- a/src/serf/dspy/optimize.py
+++ b/src/serf/dspy/optimize.py
@@ -41,13 +41,9 @@ def build_candidate_blocks(
     target_block_size: int = 30,
     sample_size: int | None = None,
     seed: int = 0,
+    require_true_pair: bool = True,
 ) -> list[EntityBlock]:
-    """Block a (sub)sample of a benchmark and keep only blocks with a true match.
-
-    A block containing no true pair at all is trivial to resolve correctly
-    (the answer is "nothing merges") and teaches the optimizer little; blocks
-    with at least one true pair have both a merge decision and, typically,
-    several correct non-merges to get right in the same call.
+    """Block a (sub)sample of a benchmark, for use as GEPA training data.
 
     Parameters
     ----------
@@ -62,11 +58,17 @@ def build_candidate_blocks(
         the full dataset.
     seed : int
         Random seed for sampling
+    require_true_pair : bool
+        If True (default), drop blocks with no true pair at all -- trivial
+        to resolve (the answer is always "nothing merges") and, in
+        isolation, teaches the optimizer little. Set False for a
+        substantially larger, more production-realistic training set that
+        also exercises correct non-merging on blocks with no match at all.
 
     Returns
     -------
     list[EntityBlock]
-        Blocks that contain at least one true matching pair
+        Candidate blocks, optionally filtered to those with >=1 true pair
     """
     left, right = dataset.to_entities()
     all_entities = left + right
@@ -103,6 +105,9 @@ def build_candidate_blocks(
         target_block_size=target_block_size, max_block_size=target_block_size
     )
     blocks, _ = pipeline.run(all_entities)
+
+    if not require_true_pair:
+        return blocks
 
     labeled_blocks = []
     for block in blocks:
@@ -441,10 +446,11 @@ def run_gepa_optimization(
     dataset_name: str,
     task_model: str,
     reflection_model: str,
-    sample_size: int = 60,
+    sample_size: int | None = 60,
     target_block_size: int = 30,
     auto: str | None = "light",
     max_metric_calls: int | None = None,
+    require_true_pair: bool = True,
     seed: int = 0,
 ) -> dict[str, object]:
     """End-to-end: build labeled blocks, split, optimize BlockMatch with GEPA,
@@ -459,14 +465,19 @@ def run_gepa_optimization(
         Student/task LM, e.g. "gemini/gemini-3.5-flash-lite"
     reflection_model : str
         GEPA's reflection_lm, e.g. "gemini/gemini-3.7-flash"
-    sample_size : int
-        Number of ground-truth pairs' entities to sample before blocking
+    sample_size : int | None
+        Number of ground-truth pairs' entities to sample before blocking.
+        None blocks the full dataset, for the largest possible training set.
     target_block_size : int
         Target entities per block
     auto : str | None
         GEPA's auto budget: "light", "medium", or "heavy". Mutually
         exclusive with max_metric_calls; set this to None when passing
         max_metric_calls explicitly.
+    require_true_pair : bool
+        If True (default), only train on blocks with >=1 true pair. Set
+        False for a substantially larger, more production-realistic
+        training set (see build_candidate_blocks).
     max_metric_calls : int | None
         Explicit cap on the number of metric calls GEPA may make, for
         predictable runtime independent of trainset size. Takes precedence
@@ -481,9 +492,13 @@ def run_gepa_optimization(
     """
     dataset = BenchmarkDataset.download(dataset_name)
     blocks = build_candidate_blocks(
-        dataset, target_block_size=target_block_size, sample_size=sample_size, seed=seed
+        dataset,
+        target_block_size=target_block_size,
+        sample_size=sample_size,
+        seed=seed,
+        require_true_pair=require_true_pair,
     )
-    logger.info(f"Built {len(blocks)} labeled blocks (>=1 true pair) from {dataset_name}")
+    logger.info(f"Built {len(blocks)} candidate blocks from {dataset_name}")
 
     examples = build_gepa_examples(blocks, dataset.ground_truth)
     rng = random.Random(seed)

--- a/src/serf/dspy/optimize.py
+++ b/src/serf/dspy/optimize.py
@@ -19,7 +19,7 @@ import dspy
 # isort: on
 import random
 from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from serf.block.pipeline import SemanticBlockingPipeline
 from serf.dspy.adapters import RobustXMLAdapter
@@ -29,6 +29,9 @@ from serf.eval.benchmarks import BenchmarkDataset
 from serf.logs import get_logger
 from serf.match.few_shot import get_default_few_shot_examples
 from serf.match.uuid_mapper import UUIDMapper
+
+if TYPE_CHECKING:
+    from serf.dspy.budget import TrackedLM
 
 logger = get_logger(__name__)
 
@@ -331,6 +334,77 @@ def er_metric(
     return dspy.Prediction(score=score, feedback=" ".join(feedback_parts))
 
 
+def _build_tracked_lm(model: str, temperature: float, max_tokens: int) -> "TrackedLM":
+    """Build a TrackedLM for either the Gemini Developer API or gpt-oss-*-maas
+    on Vertex AI, routed by model name (docs/SERF_LONG_SHOT_PLAN.md Section 7.9).
+
+    Parameters
+    ----------
+    model : str
+        Model identifier, e.g. "gemini/gemini-3.5-flash-lite" or
+        "openai/gpt-oss-120b-maas"
+    temperature : float
+        Sampling temperature
+    max_tokens : int
+        Max output tokens
+
+    Returns
+    -------
+    TrackedLM
+        A TrackedLM ready to use, billed against the matching named ledger
+
+    Raises
+    ------
+    ValueError
+        If a gpt-oss-*-maas model is requested without GOOGLE_CLOUD_PROJECT
+        set (no GEMINI_API_KEY substitute exists for Vertex AI; see
+        docs/SERF_LONG_SHOT_PLAN.md Section 7.9)
+    google.auth.exceptions.DefaultCredentialsError
+        If GOOGLE_CLOUD_PROJECT is set but Application Default Credentials
+        are not configured (no `gcloud auth application-default login` and
+        no GOOGLE_APPLICATION_CREDENTIALS service-account key)
+    """
+    import os
+
+    from serf.dspy.budget import TrackedLM, get_ledger
+
+    if "gpt-oss" in model:
+        import google.auth.transport.requests
+
+        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT")
+        if not project_id:
+            raise ValueError(
+                "GOOGLE_CLOUD_PROJECT environment variable required for "
+                f"{model} (Vertex AI Model-as-a-Service; see "
+                "docs/SERF_LONG_SHOT_PLAN.md Section 7.9). Also requires "
+                "Application Default Credentials: `gcloud auth "
+                "application-default login`, or a service-account key via "
+                "GOOGLE_APPLICATION_CREDENTIALS."
+            )
+        region = os.environ.get("GOOGLE_CLOUD_REGION", "us-central1")
+        creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        creds.refresh(google.auth.transport.requests.Request())
+        return TrackedLM(
+            model,
+            ledger=get_ledger("gpt_oss_120b_maas"),
+            api_base=(
+                f"https://{region}-aiplatform.googleapis.com/v1/projects/"
+                f"{project_id}/locations/{region}/endpoints/openapi"
+            ),
+            api_key=creds.token,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    return TrackedLM(
+        model,
+        ledger=get_ledger("gemini"),
+        api_key=os.environ["GEMINI_API_KEY"],
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+
+
 def evaluate_program(
     program: Callable[..., dspy.Prediction], examples: list[dspy.Example]
 ) -> float:
@@ -405,10 +479,6 @@ def run_gepa_optimization(
     dict[str, object]
         baseline_f1, optimized_f1, n_train, n_val, n_test, optimized_program
     """
-    import os
-
-    from serf.dspy.budget import TrackedLM, get_ledger
-
     dataset = BenchmarkDataset.download(dataset_name)
     blocks = build_candidate_blocks(
         dataset, target_block_size=target_block_size, sample_size=sample_size, seed=seed
@@ -426,28 +496,18 @@ def run_gepa_optimization(
     testset = examples[n_train + n_val :]
     logger.info(f"Split: {len(trainset)} train, {len(valset)} val, {len(testset)} test (sealed)")
 
-    api_key = os.environ["GEMINI_API_KEY"]
     # Task LM stays at temperature=0, matching production (EntityMatcher):
     # an optimized prompt is only useful if it was tuned under the same
-    # deterministic conditions it will actually run under. Only the
-    # reflection_lm benefits from higher temperature (DSPy's GEPA convention
-    # for creative instruction proposals, Section 7.7 of the plan doc).
+    # conditions it will actually run under. The reflection_lm uses 1.0
+    # (DSPy's GEPA convention for creative instruction proposals, Section
+    # 7.7 of the plan doc; also required for reliable behavior specifically
+    # on Gemini 3.x models, per LiteLLM's own provider guidance).
     from serf.config import config as serf_config
 
     max_output_tokens = serf_config.get("er.matching.max_output_tokens", 65536)
-    task_lm = TrackedLM(
-        task_model,
-        ledger=get_ledger("gemini"),
-        api_key=api_key,
-        temperature=0.0,
-        max_tokens=max_output_tokens,
-    )
-    reflection_lm = TrackedLM(
-        reflection_model,
-        ledger=get_ledger("gemini"),
-        api_key=api_key,
-        temperature=1.0,
-        max_tokens=max_output_tokens,
+    task_lm = _build_tracked_lm(task_model, temperature=0.0, max_tokens=max_output_tokens)
+    reflection_lm = _build_tracked_lm(
+        reflection_model, temperature=1.0, max_tokens=max_output_tokens
     )
     dspy.configure(lm=task_lm, adapter=RobustXMLAdapter())
 

--- a/src/serf/dspy/optimize.py
+++ b/src/serf/dspy/optimize.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 from serf.block.pipeline import SemanticBlockingPipeline
+from serf.dspy.adapters import RobustXMLAdapter
 from serf.dspy.signatures import BlockMatch
 from serf.dspy.types import BlockResolution, Entity, EntityBlock
 from serf.eval.benchmarks import BenchmarkDataset
@@ -79,7 +80,15 @@ def build_candidate_blocks(
         entity_by_id = {e.id: e for e in all_entities}
         all_entities = [entity_by_id[i] for i in sampled_ids if i in entity_by_id]
 
-    pipeline = SemanticBlockingPipeline(target_block_size=target_block_size)
+    # Cap max_block_size at target_block_size itself (rather than the
+    # pipeline's normal 100 default): with a small, true-pair-biased sample,
+    # unsupervised clustering produces a few outsized, disproportionately
+    # dense blocks (observed: 71- and 41-entity blocks from a target of 30),
+    # and those are exactly the blocks that most often fail to parse -- this
+    # is itself evidence for RESEARCH_LOOP.md's E1 block-size hypothesis.
+    pipeline = SemanticBlockingPipeline(
+        target_block_size=target_block_size, max_block_size=target_block_size
+    )
     blocks, _ = pipeline.run(all_entities)
 
     labeled_blocks = []
@@ -401,11 +410,29 @@ def run_gepa_optimization(
     logger.info(f"Split: {len(trainset)} train, {len(valset)} val, {len(testset)} test (sealed)")
 
     api_key = os.environ["GEMINI_API_KEY"]
-    task_lm = TrackedLM(task_model, ledger=get_ledger("gemini"), api_key=api_key, temperature=1.0)
-    reflection_lm = TrackedLM(
-        reflection_model, ledger=get_ledger("gemini"), api_key=api_key, temperature=1.0
+    # Task LM stays at temperature=0, matching production (EntityMatcher):
+    # an optimized prompt is only useful if it was tuned under the same
+    # deterministic conditions it will actually run under. Only the
+    # reflection_lm benefits from higher temperature (DSPy's GEPA convention
+    # for creative instruction proposals, Section 7.7 of the plan doc).
+    from serf.config import config as serf_config
+
+    max_output_tokens = serf_config.get("er.matching.max_output_tokens", 65536)
+    task_lm = TrackedLM(
+        task_model,
+        ledger=get_ledger("gemini"),
+        api_key=api_key,
+        temperature=0.0,
+        max_tokens=max_output_tokens,
     )
-    dspy.configure(lm=task_lm, adapter=dspy.XMLAdapter())
+    reflection_lm = TrackedLM(
+        reflection_model,
+        ledger=get_ledger("gemini"),
+        api_key=api_key,
+        temperature=1.0,
+        max_tokens=max_output_tokens,
+    )
+    dspy.configure(lm=task_lm, adapter=RobustXMLAdapter())
 
     student = cast(dspy.Module, dspy.Predict(BlockMatch))
     baseline_f1 = evaluate_program(student, testset)

--- a/src/serf/dspy/optimize.py
+++ b/src/serf/dspy/optimize.py
@@ -53,8 +53,9 @@ def build_candidate_blocks(
     target_block_size : int
         Target entities per block for the real FAISS blocking pipeline
     sample_size : int | None
-        If set, sample this many (left, right) ground-truth pairs' entities
-        plus surrounding context before blocking, to bound cost. None blocks
+        If set, sample roughly this many true-pair entities plus an equal
+        number of random distractor entities before blocking (~2x total),
+        to bound cost while still presenting genuine ambiguity. None blocks
         the full dataset.
     seed : int
         Random seed for sampling
@@ -77,6 +78,15 @@ def build_candidate_blocks(
                 break
             sampled_ids.add(a)
             sampled_ids.add(b)
+        # Add an equal number of random "distractor" entities. Sampling only
+        # true-pair members produces artificially easy blocks (every entity
+        # already has an obvious partner) and was measured to hit a perfect
+        # F1 ceiling on both the baseline and GEPA-optimized program, leaving
+        # no signal for the optimizer. Real production blocks mix matches
+        # with plausible near-miss non-matches; this approximates that.
+        remaining = [e.id for e in all_entities if e.id not in sampled_ids]
+        rng.shuffle(remaining)
+        sampled_ids.update(remaining[: len(sampled_ids)])
         entity_by_id = {e.id: e for e in all_entities}
         all_entities = [entity_by_id[i] for i in sampled_ids if i in entity_by_id]
 
@@ -359,7 +369,8 @@ def run_gepa_optimization(
     reflection_model: str,
     sample_size: int = 60,
     target_block_size: int = 30,
-    auto: str = "light",
+    auto: str | None = "light",
+    max_metric_calls: int | None = None,
     seed: int = 0,
 ) -> dict[str, object]:
     """End-to-end: build labeled blocks, split, optimize BlockMatch with GEPA,
@@ -378,8 +389,14 @@ def run_gepa_optimization(
         Number of ground-truth pairs' entities to sample before blocking
     target_block_size : int
         Target entities per block
-    auto : str
-        GEPA's auto budget: "light", "medium", or "heavy"
+    auto : str | None
+        GEPA's auto budget: "light", "medium", or "heavy". Mutually
+        exclusive with max_metric_calls; set this to None when passing
+        max_metric_calls explicitly.
+    max_metric_calls : int | None
+        Explicit cap on the number of metric calls GEPA may make, for
+        predictable runtime independent of trainset size. Takes precedence
+        over `auto` when both would otherwise be considered.
     seed : int
         Random seed for the train/val/test split
 
@@ -438,11 +455,11 @@ def run_gepa_optimization(
     baseline_f1 = evaluate_program(student, testset)
     logger.info(f"Baseline (hand-written) test F1: {baseline_f1:.4f}")
 
-    auto_literal = cast(Any, auto)
     optimizer = dspy.GEPA(
         metric=cast(Any, er_metric),
         reflection_lm=reflection_lm,
-        auto=auto_literal,
+        auto=None if max_metric_calls else cast(Any, auto),
+        max_metric_calls=max_metric_calls,
         num_threads=4,
         track_stats=True,
     )

--- a/src/serf/dspy/optimize.py
+++ b/src/serf/dspy/optimize.py
@@ -1,0 +1,426 @@
+"""GEPA-based reflective optimization for SERF's BlockMatch signature.
+
+Builds labeled blocks from a benchmark's ground truth, optimizes BlockMatch's
+instructions with dspy.GEPA against a held-out validation split (the test
+split stays sealed until final evaluation, per docs/RESEARCH_LOOP.md Section 5
+rule 5), and reports the optimized program's F1 against the hand-written
+baseline.
+"""
+
+import random
+from collections.abc import Callable
+from typing import Any, cast
+
+import dspy
+
+from serf.block.pipeline import SemanticBlockingPipeline
+from serf.dspy.signatures import BlockMatch
+from serf.dspy.types import BlockResolution, Entity, EntityBlock
+from serf.eval.benchmarks import BenchmarkDataset
+from serf.logs import get_logger
+from serf.match.few_shot import get_default_few_shot_examples
+from serf.match.uuid_mapper import UUIDMapper
+
+logger = get_logger(__name__)
+
+
+def build_candidate_blocks(
+    dataset: BenchmarkDataset,
+    target_block_size: int = 30,
+    sample_size: int | None = None,
+    seed: int = 0,
+) -> list[EntityBlock]:
+    """Block a (sub)sample of a benchmark and keep only blocks with a true match.
+
+    A block containing no true pair at all is trivial to resolve correctly
+    (the answer is "nothing merges") and teaches the optimizer little; blocks
+    with at least one true pair have both a merge decision and, typically,
+    several correct non-merges to get right in the same call.
+
+    Parameters
+    ----------
+    dataset : BenchmarkDataset
+        Benchmark providing entities and ground truth
+    target_block_size : int
+        Target entities per block for the real FAISS blocking pipeline
+    sample_size : int | None
+        If set, sample this many (left, right) ground-truth pairs' entities
+        plus surrounding context before blocking, to bound cost. None blocks
+        the full dataset.
+    seed : int
+        Random seed for sampling
+
+    Returns
+    -------
+    list[EntityBlock]
+        Blocks that contain at least one true matching pair
+    """
+    left, right = dataset.to_entities()
+    all_entities = left + right
+
+    if sample_size is not None:
+        rng = random.Random(seed)
+        gt_list = sorted(dataset.ground_truth)
+        rng.shuffle(gt_list)
+        sampled_ids: set[int] = set()
+        for a, b in gt_list:
+            if len(sampled_ids) >= sample_size:
+                break
+            sampled_ids.add(a)
+            sampled_ids.add(b)
+        entity_by_id = {e.id: e for e in all_entities}
+        all_entities = [entity_by_id[i] for i in sampled_ids if i in entity_by_id]
+
+    pipeline = SemanticBlockingPipeline(target_block_size=target_block_size)
+    blocks, _ = pipeline.run(all_entities)
+
+    labeled_blocks = []
+    for block in blocks:
+        ids_in_block = {e.id for e in block.entities}
+        has_true_pair = any(
+            a in ids_in_block and b in ids_in_block for a, b in dataset.ground_truth
+        )
+        if has_true_pair:
+            labeled_blocks.append(block)
+    return labeled_blocks
+
+
+def gold_resolution_for_block(
+    block: EntityBlock, ground_truth: set[tuple[int, int]]
+) -> BlockResolution:
+    """Compute the correct BlockResolution for a block from ground truth pairs.
+
+    Groups the block's entities into connected components under the
+    ground-truth match relation restricted to this block, then applies the
+    MDM convention (docs/ID_INVARIANTS.md Section 3): the lowest id in each
+    component becomes the master, all others go into its source_ids.
+
+    Parameters
+    ----------
+    block : EntityBlock
+        Block of entities (real, pre-mapping ids)
+    ground_truth : set[tuple[int, int]]
+        All true (left_id, right_id) matching pairs for the dataset
+
+    Returns
+    -------
+    BlockResolution
+        Gold resolution: matches, merged/standalone resolved_entities
+    """
+    ids_in_block = {e.id for e in block.entities}
+    relevant_pairs = [(a, b) for a, b in ground_truth if a in ids_in_block and b in ids_in_block]
+
+    parent: dict[int, int] = {e.id: e.id for e in block.entities}
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[max(ra, rb)] = min(ra, rb)
+
+    for a, b in relevant_pairs:
+        union(a, b)
+
+    components: dict[int, list[int]] = {}
+    for e in block.entities:
+        components.setdefault(find(e.id), []).append(e.id)
+
+    entity_by_id = {e.id: e for e in block.entities}
+    resolved_entities: list[Entity] = []
+    matches = []
+    for member_ids in components.values():
+        member_ids.sort()
+        master_id = member_ids[0]
+        master = entity_by_id[master_id]
+        if len(member_ids) > 1:
+            resolved_entities.append(master.model_copy(update={"source_ids": member_ids[1:]}))
+            for other_id in member_ids[1:]:
+                matches.append(
+                    {"entity_a_id": master_id, "entity_b_id": other_id, "is_match": True}
+                )
+        else:
+            resolved_entities.append(master.model_copy())
+
+    from serf.dspy.types import MatchDecision
+
+    return BlockResolution(
+        block_key=block.block_key,
+        matches=[
+            MatchDecision(
+                entity_a_id=m["entity_a_id"],
+                entity_b_id=m["entity_b_id"],
+                is_match=True,
+                confidence=1.0,
+                reasoning="ground truth",
+            )
+            for m in matches
+        ],
+        resolved_entities=resolved_entities,
+        was_resolved=any(len(v) > 1 for v in components.values()),
+        original_count=len(block.entities),
+        resolved_count=len(resolved_entities),
+    )
+
+
+def resolution_to_pairs(resolution: BlockResolution) -> set[tuple[int, int]]:
+    """Extract all implied (a, b) match pairs from a resolution's source_ids.
+
+    Parameters
+    ----------
+    resolution : BlockResolution
+        A resolution (gold or predicted)
+
+    Returns
+    -------
+    set[tuple[int, int]]
+        Normalized (min_id, max_id) pairs implied by every merge
+    """
+    pairs: set[tuple[int, int]] = set()
+    for e in resolution.resolved_entities:
+        for sid in e.source_ids or []:
+            if sid != e.id:
+                pairs.add((min(e.id, sid), max(e.id, sid)))
+    return pairs
+
+
+def build_gepa_examples(
+    blocks: list[EntityBlock], ground_truth: set[tuple[int, int]]
+) -> list[dspy.Example]:
+    """Build GEPA-ready examples: one per block, ids mapped exactly as
+    EntityMatcher would map them for a real LLM call, with a mapped gold
+    resolution as the label.
+
+    Parameters
+    ----------
+    blocks : list[EntityBlock]
+        Labeled blocks (real, pre-mapping ids)
+    ground_truth : set[tuple[int, int]]
+        All true (left_id, right_id) matching pairs for the dataset
+
+    Returns
+    -------
+    list[dspy.Example]
+        Examples with inputs block_records/schema_info/few_shot_examples
+        and label resolution, all in block-local mapped-id space
+    """
+    from serf.match.matcher import SCHEMA_INFO
+
+    few_shot = get_default_few_shot_examples()
+    examples = []
+    for block in blocks:
+        gold = gold_resolution_for_block(block, ground_truth)
+        mapper = UUIDMapper()
+        mapped_block = mapper.map_block(block)
+        mapped_gold = _map_gold_resolution(gold, mapper)
+
+        block_records = "\n".join(str(e.model_dump(mode="json")) for e in mapped_block.entities)
+        example = dspy.Example(
+            block_records=block_records,
+            schema_info=SCHEMA_INFO,
+            few_shot_examples=few_shot,
+            resolution=mapped_gold,
+        ).with_inputs("block_records", "schema_info", "few_shot_examples")
+        examples.append(example)
+    return examples
+
+
+def _map_gold_resolution(gold: BlockResolution, mapper: UUIDMapper) -> BlockResolution:
+    """Re-express a gold resolution's real ids as the mapper's mapped ids.
+
+    Parameters
+    ----------
+    gold : BlockResolution
+        Gold resolution in real (pre-mapping) id space
+    mapper : UUIDMapper
+        A mapper that has already run map_block on the corresponding block
+
+    Returns
+    -------
+    BlockResolution
+        Gold resolution with ids translated into mapped-id space
+    """
+    mapped_entities = []
+    for e in gold.resolved_entities:
+        mapped_id = mapper._id_to_int[e.id]
+        mapped_source_ids = [mapper._id_to_int[sid] for sid in (e.source_ids or [])]
+        mapped_entities.append(
+            e.model_copy(update={"id": mapped_id, "source_ids": mapped_source_ids or None})
+        )
+    return gold.model_copy(update={"resolved_entities": mapped_entities})
+
+
+def er_metric(
+    gold: dspy.Example,
+    pred: dspy.Prediction,
+    trace: object = None,
+    pred_name: str | None = None,
+    pred_trace: object = None,
+) -> dspy.Prediction:
+    """Score a BlockMatch prediction against gold and explain the score.
+
+    Parameters
+    ----------
+    gold : dspy.Example
+        Example with the gold `resolution`
+    pred : dspy.Prediction
+        Model output with a predicted `resolution`
+    trace : object
+        Unused; part of the GEPA metric protocol
+    pred_name : str | None
+        Unused; part of the GEPA metric protocol
+    pred_trace : object
+        Unused; part of the GEPA metric protocol
+
+    Returns
+    -------
+    dspy.Prediction
+        `score` (pairwise F1 in [0, 1]) and `feedback` (text explaining
+        missed/extra merges, for the reflection_lm to read)
+    """
+    from serf.eval.metrics import f1_score
+
+    try:
+        gold_pairs = resolution_to_pairs(gold.resolution)
+        pred_pairs = resolution_to_pairs(pred.resolution)
+    except Exception as e:
+        return dspy.Prediction(score=0.0, feedback=f"Failed to parse resolution: {e}")
+
+    score = f1_score(pred_pairs, gold_pairs)
+    missed = gold_pairs - pred_pairs
+    extra = pred_pairs - gold_pairs
+    feedback_parts = [f"Pairwise F1: {score:.3f}."]
+    if missed:
+        feedback_parts.append(f"Missed {len(missed)} true match(es): {sorted(missed)[:10]}.")
+    if extra:
+        feedback_parts.append(
+            f"Incorrectly merged {len(extra)} non-match(es): {sorted(extra)[:10]}."
+        )
+    if not missed and not extra:
+        feedback_parts.append("All matches correct.")
+    return dspy.Prediction(score=score, feedback=" ".join(feedback_parts))
+
+
+def evaluate_program(
+    program: Callable[..., dspy.Prediction], examples: list[dspy.Example]
+) -> float:
+    """Average pairwise F1 of a program over a set of examples.
+
+    Parameters
+    ----------
+    program : Callable[..., dspy.Prediction]
+        A BlockMatch-shaped callable (e.g. dspy.Predict(BlockMatch) or GEPA output)
+    examples : list[dspy.Example]
+        Examples with gold `resolution` labels
+
+    Returns
+    -------
+    float
+        Mean pairwise F1 across examples (0.0 for examples where the call fails)
+    """
+    scores = []
+    for ex in examples:
+        try:
+            pred = program(
+                block_records=ex.block_records,
+                schema_info=ex.schema_info,
+                few_shot_examples=ex.few_shot_examples,
+            )
+            scores.append(er_metric(ex, pred).score)
+        except Exception as e:
+            logger.warning(f"Evaluation call failed: {e}")
+            scores.append(0.0)
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def run_gepa_optimization(
+    dataset_name: str,
+    task_model: str,
+    reflection_model: str,
+    sample_size: int = 60,
+    target_block_size: int = 30,
+    auto: str = "light",
+    seed: int = 0,
+) -> dict[str, object]:
+    """End-to-end: build labeled blocks, split, optimize BlockMatch with GEPA,
+    and evaluate the optimized program against the hand-written baseline on
+    a sealed test split.
+
+    Parameters
+    ----------
+    dataset_name : str
+        Benchmark dataset name (e.g. "dblp-acm")
+    task_model : str
+        Student/task LM, e.g. "gemini/gemini-3.5-flash-lite"
+    reflection_model : str
+        GEPA's reflection_lm, e.g. "gemini/gemini-3.7-flash"
+    sample_size : int
+        Number of ground-truth pairs' entities to sample before blocking
+    target_block_size : int
+        Target entities per block
+    auto : str
+        GEPA's auto budget: "light", "medium", or "heavy"
+    seed : int
+        Random seed for the train/val/test split
+
+    Returns
+    -------
+    dict[str, object]
+        baseline_f1, optimized_f1, n_train, n_val, n_test, optimized_program
+    """
+    import os
+
+    from serf.dspy.budget import TrackedLM, get_ledger
+
+    dataset = BenchmarkDataset.download(dataset_name)
+    blocks = build_candidate_blocks(
+        dataset, target_block_size=target_block_size, sample_size=sample_size, seed=seed
+    )
+    logger.info(f"Built {len(blocks)} labeled blocks (>=1 true pair) from {dataset_name}")
+
+    examples = build_gepa_examples(blocks, dataset.ground_truth)
+    rng = random.Random(seed)
+    rng.shuffle(examples)
+    n = len(examples)
+    n_train = max(1, int(n * 0.5))
+    n_val = max(1, int(n * 0.25))
+    trainset = examples[:n_train]
+    valset = examples[n_train : n_train + n_val]
+    testset = examples[n_train + n_val :]
+    logger.info(f"Split: {len(trainset)} train, {len(valset)} val, {len(testset)} test (sealed)")
+
+    api_key = os.environ["GEMINI_API_KEY"]
+    task_lm = TrackedLM(task_model, ledger=get_ledger("gemini"), api_key=api_key, temperature=1.0)
+    reflection_lm = TrackedLM(
+        reflection_model, ledger=get_ledger("gemini"), api_key=api_key, temperature=1.0
+    )
+    dspy.configure(lm=task_lm, adapter=dspy.XMLAdapter())
+
+    student = cast(dspy.Module, dspy.Predict(BlockMatch))
+    baseline_f1 = evaluate_program(student, testset)
+    logger.info(f"Baseline (hand-written) test F1: {baseline_f1:.4f}")
+
+    auto_literal = cast(Any, auto)
+    optimizer = dspy.GEPA(
+        metric=cast(Any, er_metric),
+        reflection_lm=reflection_lm,
+        auto=auto_literal,
+        num_threads=4,
+        track_stats=True,
+    )
+    optimized = optimizer.compile(student, trainset=trainset, valset=valset)
+
+    optimized_f1 = evaluate_program(optimized, testset)
+    logger.info(f"Optimized (GEPA) test F1: {optimized_f1:.4f}")
+
+    return {
+        "baseline_f1": baseline_f1,
+        "optimized_f1": optimized_f1,
+        "n_train": len(trainset),
+        "n_val": len(valset),
+        "n_test": len(testset),
+        "optimized_program": optimized,
+    }

--- a/src/serf/dspy/optimize.py
+++ b/src/serf/dspy/optimize.py
@@ -7,11 +7,19 @@ rule 5), and reports the optimized program's F1 against the hand-written
 baseline.
 """
 
+# isort: off
+# numpy must load before dspy in a fresh process: dspy lazily proxies the
+# numpy module, and if something later does `from numpy.typing import X`
+# before numpy has been imported for real, the lazy proxy re-execs numpy's
+# __init__ into an already-partially-loaded module and corrupts its C
+# extension state. serf.block.pipeline (imported below) does exactly that.
+import numpy  # noqa: F401
+import dspy
+
+# isort: on
 import random
 from collections.abc import Callable
 from typing import Any, cast
-
-import dspy
 
 from serf.block.pipeline import SemanticBlockingPipeline
 from serf.dspy.signatures import BlockMatch

--- a/src/serf/eval/baselines.py
+++ b/src/serf/eval/baselines.py
@@ -1,0 +1,133 @@
+"""Baseline matchers for entity resolution -- no LLM calls, for comparison.
+
+Per docs/RESEARCH_LOOP.md Stage 1: get the evaluation harness producing
+numbers you trust before anything else matters, and report these baselines
+"all of them, forever" alongside every SERF result. Implementations are
+vectorized (TF-IDF via sparse cosine similarity, random via sampling
+indices rather than iterating pairs) so they scale to the largest benchmark
+(DBLP-Scholar: 2,616 x 64,263 = ~168M candidate pairs).
+"""
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from serf.dspy.types import Entity
+from serf.eval.metrics import evaluate_resolution
+
+
+def random_baseline(
+    left: list[Entity],
+    right: list[Entity],
+    true_pairs: set[tuple[int, int]],
+    seed: int = 0,
+) -> dict[str, float | int]:
+    """Predict matches uniformly at random, at the observed positive rate.
+
+    Establishes the floor every other baseline, and SERF itself, must clear.
+
+    Parameters
+    ----------
+    left : list[Entity]
+        Left-table entities
+    right : list[Entity]
+        Right-table entities
+    true_pairs : set[tuple[int, int]]
+        Ground truth matching (left_id, right_id) pairs
+    seed : int
+        Random seed
+
+    Returns
+    -------
+    dict[str, float | int]
+        precision, recall, f1_score, true_positives, false_positives
+    """
+    rng = np.random.default_rng(seed)
+    total_possible = len(left) * len(right)
+    positive_rate = len(true_pairs) / total_possible if total_possible else 0.0
+    k = (
+        min(int(rng.binomial(total_possible, positive_rate)), total_possible)
+        if total_possible
+        else 0
+    )
+    flat_indices = (
+        rng.choice(total_possible, size=k, replace=False) if k else np.array([], dtype=np.int64)
+    )
+
+    n_right = len(right)
+    predicted = {
+        (left[int(idx) // n_right].id, right[int(idx) % n_right].id) for idx in flat_indices
+    }
+    return evaluate_resolution(predicted, true_pairs)
+
+
+def exact_name_match_baseline(
+    left: list[Entity],
+    right: list[Entity],
+    true_pairs: set[tuple[int, int]],
+) -> dict[str, float | int]:
+    """Predict a match wherever the normalized name field is identical.
+
+    Shockingly strong on DBLP-ACM; publishing it keeps everyone honest.
+
+    Parameters
+    ----------
+    left : list[Entity]
+        Left-table entities
+    right : list[Entity]
+        Right-table entities
+    true_pairs : set[tuple[int, int]]
+        Ground truth matching (left_id, right_id) pairs
+
+    Returns
+    -------
+    dict[str, float | int]
+        precision, recall, f1_score, true_positives, false_positives
+    """
+    right_by_name: dict[str, list[int]] = {}
+    for r in right:
+        right_by_name.setdefault(r.name.strip().lower(), []).append(r.id)
+
+    predicted: set[tuple[int, int]] = set()
+    for left_entity in left:
+        for rid in right_by_name.get(left_entity.name.strip().lower(), []):
+            predicted.add((left_entity.id, rid))
+    return evaluate_resolution(predicted, true_pairs)
+
+
+def tfidf_cosine_baseline(
+    left: list[Entity],
+    right: list[Entity],
+    true_pairs: set[tuple[int, int]],
+    threshold: float = 0.5,
+) -> dict[str, float | int]:
+    """Predict a match wherever TF-IDF cosine similarity of names exceeds threshold.
+
+    The pre-neural baseline every reviewer asks about. Computed as one sparse
+    matrix multiplication rather than a pairwise Python loop.
+
+    Parameters
+    ----------
+    left : list[Entity]
+        Left-table entities
+    right : list[Entity]
+        Right-table entities
+    true_pairs : set[tuple[int, int]]
+        Ground truth matching (left_id, right_id) pairs
+    threshold : float
+        Minimum cosine similarity to count as a match
+
+    Returns
+    -------
+    dict[str, float | int]
+        precision, recall, f1_score, true_positives, false_positives
+    """
+    corpus = [e.name for e in left] + [e.name for e in right]
+    vectorizer = TfidfVectorizer(analyzer="word", token_pattern=r"(?u)\b\w+\b")
+    tfidf = vectorizer.fit_transform(corpus)
+    left_vecs, right_vecs = tfidf[: len(left)], tfidf[len(left) :]
+    sims = cosine_similarity(left_vecs, right_vecs)
+
+    left_idx, right_idx = np.where(sims >= threshold)
+    predicted = {(left[li].id, right[ri].id) for li, ri in zip(left_idx, right_idx, strict=True)}
+    return evaluate_resolution(predicted, true_pairs)

--- a/src/serf/eval/evaluator.py
+++ b/src/serf/eval/evaluator.py
@@ -30,6 +30,7 @@ def evaluate_er_results(
     iteration: int = 1,
     historical_uuids: set[str] | None = None,
     previous_entity_count: int | None = None,
+    input_entity_ids: set[int] | None = None,
 ) -> dict[str, Any]:
     """Comprehensive evaluation of entity resolution results.
 
@@ -48,6 +49,13 @@ def evaluate_er_results(
         All UUIDs from all previous iterations (for validation)
     previous_entity_count : int | None
         Entity count from previous iteration (for per-round reduction)
+    input_entity_ids : set[int] | None
+        The exact set of entity ids that entered blocking this iteration.
+        When provided, enables the identifier_coverage gate (docs/ID_INVARIANTS.md):
+        every id must come back as a master id or inside exactly one
+        resolved entity's source_ids. Unlike uuid_validation (which checks
+        that emitted references are *valid*), this catches the case
+        uuid_validation cannot: a record vanishing with no trace at all.
 
     Returns
     -------
@@ -100,6 +108,21 @@ def evaluate_er_results(
     if historical_uuids is not None:
         uuid_validation = validate_source_uuids(unique_entities, historical_uuids)
 
+    # Step 6.5: Identifier coverage if the true input id set is provided
+    identifier_coverage: dict[str, Any] = {"skipped": True}
+    if input_entity_ids is not None:
+        output_ids: set[int] = set()
+        for e in unique_entities:
+            output_ids.add(e.id)
+            output_ids.update(e.source_ids or [])
+        missing_ids = sorted(input_entity_ids - output_ids)
+        identifier_coverage = {
+            "input_count": len(input_entity_ids),
+            "missing_count": len(missing_ids),
+            "missing_ids": missing_ids[:10],
+            "passed": len(missing_ids) == 0,
+        }
+
     # Step 7: Compute reduction metrics
     iteration_input = previous_entity_count or original_entity_count
     reduction_from_matching = iteration_input - len(unique_entities)
@@ -134,6 +157,12 @@ def evaluate_er_results(
             "passed": duplicate_rate < OVERLAP_THRESHOLD,
             "description": f"duplicate entity rate < {OVERLAP_THRESHOLD}%",
         },
+        "identifier_coverage": {
+            "value": identifier_coverage.get("missing_count", 0),
+            "threshold": 0,
+            "passed": identifier_coverage.get("passed", True),
+            "description": "every input id is a master id or in exactly one source_ids list",
+        },
     }
     overall_passed = all(c["passed"] for c in checks.values())
 
@@ -163,6 +192,7 @@ def evaluate_er_results(
             ),
         },
         "uuid_validation": uuid_validation,
+        "identifier_coverage": identifier_coverage,
         "checks": checks,
         "overall_status": "PASS" if overall_passed else "FAIL",
     }

--- a/src/serf/match/matcher.py
+++ b/src/serf/match/matcher.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import dspy
 
 from serf.config import config
+from serf.dspy.adapters import RobustXMLAdapter
 from serf.dspy.budget import TrackedLM, get_ledger
 from serf.dspy.signatures import BlockMatch
 from serf.dspy.types import BlockResolution, EntityBlock
@@ -59,7 +60,7 @@ class EntityMatcher:
         self.max_concurrent = max_concurrent or config.get("er.matching.max_concurrent", 20)
         self._predictor: dspy.Predict | None = None
         self._lm: dspy.LM | None = None
-        self._adapter = dspy.XMLAdapter()
+        self._adapter = RobustXMLAdapter()
 
     def _ensure_lm(self) -> dspy.LM:
         """Get or create the LM instance, tracked against its budget ledger."""

--- a/src/serf/match/matcher.py
+++ b/src/serf/match/matcher.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import time
 from typing import cast
 from uuid import uuid4
 
@@ -66,11 +67,12 @@ class EntityMatcher:
             if not api_key:
                 raise ValueError("GEMINI_API_KEY environment variable required")
             temperature = config.get("er.matching.temperature", 0.0)
+            max_output_tokens = config.get("er.matching.max_output_tokens", 65536)
             self._lm = dspy.LM(
                 self.model,
                 api_key=api_key,
                 temperature=temperature,
-                max_tokens=8192,
+                max_tokens=max_output_tokens,
             )
         return self._lm
 
@@ -84,6 +86,11 @@ class EntityMatcher:
     def resolve_block(self, block: EntityBlock, iteration: int = 1) -> BlockResolution:
         """Process a single block through the LLM.
 
+        A block of one entity has no possible match, so it is short-circuited
+        before any LLM call: sending it costs money, adds a chance for the
+        model to mangle it, and pollutes match_skip_reason statistics
+        (docs/ID_INVARIANTS.md D4).
+
         Parameters
         ----------
         block : EntityBlock
@@ -96,6 +103,9 @@ class EntityMatcher:
         BlockResolution
             Resolution with merged and non-matched entities
         """
+        if len(block.entities) == 1:
+            return self._singleton_resolution(block, iteration)
+
         mapper = UUIDMapper()
         mapped_block = mapper.map_block(block)
 
@@ -106,25 +116,103 @@ class EntityMatcher:
         few_shot = get_default_few_shot_examples()
 
         try:
-            lm = self._ensure_lm()
-            with dspy.context(lm=lm, adapter=self._adapter):
-                result = self.predictor(
-                    block_records=block_records,
-                    schema_info=SCHEMA_INFO,
-                    few_shot_examples=few_shot,
-                )
-            resolution = result.resolution
+            resolution = self._call_llm_with_retries(block_records, few_shot, block.block_key)
         except Exception as e:
             logger.error(f"LLM failure for block {block.block_key}: {e}")
             resolution = self._error_recovery_resolution(block, iteration)
-            return self._assign_uuids(resolution)
+            return resolution
 
         resolution = mapper.unmap_block(resolution, block)
         for e in resolution.resolved_entities:
             if e.match_skip_reason == "missing_in_match_output":
                 e.match_skip_history = list(e.match_skip_history or []) + [iteration]
-        resolution = self._assign_uuids(resolution)
+        # Only a block the model actually changed gets new identities: this
+        # is what lets cross-iteration validation tell "unchanged" apart
+        # from "resolved" (docs/ID_INVARIANTS.md D5/Section 7).
+        if resolution.was_resolved:
+            resolution = self._assign_uuids(resolution)
         return resolution
+
+    def _call_llm_with_retries(
+        self, block_records: str, few_shot: str, block_key: str
+    ) -> BlockResolution:
+        """Call the BlockMatch predictor, retrying transient failures.
+
+        Parameters
+        ----------
+        block_records : str
+            JSON array of mapped entity records
+        few_shot : str
+            Few-shot merge examples
+        block_key : str
+            Block identifier, for logging
+
+        Returns
+        -------
+        BlockResolution
+            The raw (still block-locally-mapped) LLM resolution
+
+        Raises
+        ------
+        Exception
+            The last attempt's exception, if every retry is exhausted
+        """
+        max_retries = config.get("er.matching.max_retries", 3)
+        retry_delay_ms = config.get("er.matching.retry_delay_ms", 300)
+        lm = self._ensure_lm()
+        last_error: Exception | None = None
+        for attempt in range(max_retries):
+            try:
+                with dspy.context(lm=lm, adapter=self._adapter):
+                    result = self.predictor(
+                        block_records=block_records,
+                        schema_info=SCHEMA_INFO,
+                        few_shot_examples=few_shot,
+                    )
+                return cast(BlockResolution, result.resolution)
+            except Exception as e:
+                last_error = e
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        f"Block {block_key}: LLM call failed (attempt {attempt + 1}/"
+                        f"{max_retries}), retrying: {e}"
+                    )
+                    time.sleep(retry_delay_ms / 1000)
+        assert last_error is not None
+        raise last_error
+
+    def _singleton_resolution(self, block: EntityBlock, iteration: int) -> BlockResolution:
+        """Pass a one-entity block through untouched, no LLM call.
+
+        Parameters
+        ----------
+        block : EntityBlock
+            Block containing exactly one entity
+        iteration : int
+            Current pipeline iteration number
+
+        Returns
+        -------
+        BlockResolution
+            Pass-through resolution with match_skip_reason='singleton_block'
+        """
+        entity = block.entities[0]
+        skip_history = list(entity.match_skip_history or []) + [iteration]
+        resolved = entity.model_copy(
+            update={
+                "match_skip": True,
+                "match_skip_reason": "singleton_block",
+                "match_skip_history": skip_history,
+            }
+        )
+        return BlockResolution(
+            block_key=block.block_key,
+            matches=[],
+            resolved_entities=[resolved],
+            was_resolved=False,
+            original_count=1,
+            resolved_count=1,
+        )
 
     def _error_recovery_resolution(self, block: EntityBlock, iteration: int = 1) -> BlockResolution:
         """Build resolution with all entities marked error_recovery.

--- a/src/serf/match/matcher.py
+++ b/src/serf/match/matcher.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import dspy
 
 from serf.config import config
+from serf.dspy.budget import TrackedLM, get_ledger
 from serf.dspy.signatures import BlockMatch
 from serf.dspy.types import BlockResolution, EntityBlock
 from serf.logs import get_logger
@@ -61,15 +62,17 @@ class EntityMatcher:
         self._adapter = dspy.XMLAdapter()
 
     def _ensure_lm(self) -> dspy.LM:
-        """Get or create the LM instance."""
+        """Get or create the LM instance, tracked against its budget ledger."""
         if self._lm is None:
             api_key = os.environ.get("GEMINI_API_KEY")
             if not api_key:
                 raise ValueError("GEMINI_API_KEY environment variable required")
             temperature = config.get("er.matching.temperature", 0.0)
             max_output_tokens = config.get("er.matching.max_output_tokens", 65536)
-            self._lm = dspy.LM(
+            ledger_name = "gpt_oss_120b_maas" if "gpt-oss" in self.model else "gemini"
+            self._lm = TrackedLM(
                 self.model,
+                ledger=get_ledger(ledger_name),
                 api_key=api_key,
                 temperature=temperature,
                 max_tokens=max_output_tokens,

--- a/src/serf/match/uuid_mapper.py
+++ b/src/serf/match/uuid_mapper.py
@@ -36,14 +36,17 @@ class UUIDMapper:
         Returns
         -------
         EntityBlock
-            New block with mapped IDs (0, 1, 2, ...) and source_uuids stripped
+            New block with mapped IDs (1, 2, 3, ...) and source_ids/source_uuids
+            stripped. Mapped ids start at 1, not 0: models conflate 0 with
+            null/absent in structured output (docs/ID_INVARIANTS.md D6).
         """
         self._id_to_int.clear()
         self._int_to_original.clear()
         self._mapped_ids.clear()
 
         mapped_entities: list[Entity] = []
-        for i, entity in enumerate(block.entities):
+        for offset, entity in enumerate(block.entities):
+            i = offset + 1
             self._id_to_int[entity.id] = i
             self._mapped_ids.add(entity.id)
             self._int_to_original[i] = {
@@ -54,9 +57,16 @@ class UUIDMapper:
                 "entity": entity,
             }
 
+            # source_ids MUST be cleared here, not just uuid/source_uuids: a
+            # prior round's real-id provenance would otherwise occupy the same
+            # numeric space as this round's block-local mapped ints, and
+            # unmapping would resolve it against the wrong record
+            # (docs/ID_INVARIANTS.md D1). The cached copy above is what
+            # restores it correctly after the call.
             mapped_entity = entity.model_copy(deep=True)
             mapped_entity.id = i
             mapped_entity.uuid = None
+            mapped_entity.source_ids = None
             mapped_entity.source_uuids = None
             mapped_entities.append(mapped_entity)
 
@@ -104,12 +114,19 @@ class UUIDMapper:
                 f"missing from LLM output, recovering as singletons"
             )
 
-        # Recover missing entities as un-merged singletons
+        # Recover missing entities as un-merged singletons. A recovered
+        # record is not a merge master, so the "master excludes its own id"
+        # convention (see below) does not apply: its own id is forced into
+        # its own source_ids so coverage validation counts it as accounted
+        # for (docs/ID_INVARIANTS.md Section 5, Phase 2, point 2).
         for mapped_id in sorted(missing_ids):
             orig = self._int_to_original[mapped_id]
             entity = orig["entity"].model_copy(deep=True)
             entity.match_skip = True
             entity.match_skip_reason = "missing_in_match_output"
+            self_id = orig["id"]
+            if self_id not in (entity.source_ids or []):
+                entity.source_ids = [*(entity.source_ids or []), self_id]
             resolution.resolved_entities.append(entity)
 
         # Restore IDs and source_uuids for all resolved entities

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,38 @@
+"""Tests for RobustXMLAdapter's ampersand-escaping fix."""
+
+from serf.dspy.adapters import escape_bare_ampersands
+
+
+def test_bare_ampersand_gets_escaped() -> None:
+    """A literal '&' with no following entity name is escaped."""
+    assert escape_bare_ampersands("Black & White") == "Black &amp; White"
+
+
+def test_already_escaped_ampersand_is_left_alone() -> None:
+    """An already-valid &amp; is not double-escaped."""
+    assert escape_bare_ampersands("Black &amp; White") == "Black &amp; White"
+
+
+def test_named_entities_are_left_alone() -> None:
+    """Other standard XML named entities are recognized and untouched."""
+    for entity in ("&lt;", "&gt;", "&quot;", "&apos;"):
+        text = f"before {entity} after"
+        assert escape_bare_ampersands(text) == text
+
+
+def test_numeric_entities_are_left_alone() -> None:
+    """Decimal and hex numeric character references are untouched."""
+    assert escape_bare_ampersands("&#65;") == "&#65;"
+    assert escape_bare_ampersands("&#x41;") == "&#x41;"
+
+
+def test_multiple_bare_ampersands_all_get_escaped() -> None:
+    """Every bare ampersand in a string is escaped, not just the first."""
+    result = escape_bare_ampersands("A & B & C")
+    assert result == "A &amp; B &amp; C"
+
+
+def test_mixed_bare_and_valid_ampersands() -> None:
+    """A string mixing already-valid and bare ampersands only fixes the bare ones."""
+    result = escape_bare_ampersands("Tom &amp; Jerry & Friends")
+    assert result == "Tom &amp; Jerry &amp; Friends"

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -1,0 +1,92 @@
+"""Tests for no-LLM baseline matchers."""
+
+from serf.dspy.types import Entity
+from serf.eval.baselines import exact_name_match_baseline, random_baseline, tfidf_cosine_baseline
+
+
+def _entities(names: list[str], id_offset: int = 0) -> list[Entity]:
+    return [Entity(id=id_offset + i, name=n) for i, n in enumerate(names)]
+
+
+def test_random_baseline_predicted_count_matches_positive_rate() -> None:
+    """Random predicts roughly len(true_pairs) pairs total, since it samples
+    at the observed positive rate rather than a fixed threshold."""
+    left = _entities(["A", "B", "C", "D"])
+    right = _entities(["E", "F", "G", "H"], id_offset=100)
+    true_pairs = {(0, 100), (1, 101)}
+    metrics = random_baseline(left, right, true_pairs, seed=0)
+    # With only 16 candidate pairs and rate 2/16, the exact count is noisy,
+    # but true_positives + false_positives should be small and plausible.
+    assert metrics["true_positives"] + metrics["false_positives"] <= 16
+
+
+def test_random_baseline_empty_true_pairs_predicts_nothing() -> None:
+    """Zero observed positive rate means random predicts an empty set."""
+    left = _entities(["A", "B"])
+    right = _entities(["C", "D"], id_offset=100)
+    metrics = random_baseline(left, right, true_pairs=set(), seed=0)
+    assert metrics["true_positives"] == 0
+    assert metrics["false_positives"] == 0
+
+
+def test_random_baseline_scales_to_large_dataset() -> None:
+    """Must not materialize O(N*M) candidate pairs (DBLP-Scholar is ~168M);
+    this should complete quickly for a similarly-shaped small-rate case."""
+    left = _entities([f"L{i}" for i in range(3000)])
+    right = _entities([f"R{i}" for i in range(60000)], id_offset=1_000_000)
+    true_pairs = {(0, 1_000_000), (1, 1_000_001)}
+    metrics = random_baseline(left, right, true_pairs, seed=0)
+    assert metrics["true_positives"] + metrics["false_positives"] < 100
+
+
+def test_exact_name_match_finds_identical_names() -> None:
+    """Identical names across tables are predicted as matches."""
+    left = _entities(["Same Title", "Unique A"])
+    right = _entities(["Same Title", "Unique B"], id_offset=100)
+    true_pairs = {(0, 100)}
+    metrics = exact_name_match_baseline(left, right, true_pairs)
+    assert metrics["true_positives"] == 1
+    assert metrics["false_positives"] == 0
+    assert metrics["recall"] == 1.0
+
+
+def test_exact_name_match_is_case_and_whitespace_insensitive() -> None:
+    """Normalization (strip + lowercase) still counts a match."""
+    left = _entities(["  Machine Learning  "])
+    right = _entities(["machine learning"], id_offset=100)
+    metrics = exact_name_match_baseline(left, right, {(0, 100)})
+    assert metrics["true_positives"] == 1
+
+
+def test_exact_name_match_no_false_positives_from_distinct_names() -> None:
+    """Distinct names never get linked, even with no ground truth."""
+    left = _entities(["Alpha"])
+    right = _entities(["Beta"], id_offset=100)
+    metrics = exact_name_match_baseline(left, right, set())
+    assert metrics["true_positives"] == 0
+    assert metrics["false_positives"] == 0
+
+
+def test_tfidf_cosine_finds_near_duplicate_names() -> None:
+    """Names sharing most tokens score above threshold; unrelated ones don't."""
+    left = _entities(["Deep Learning for Entity Matching", "Totally Unrelated Topic"])
+    right = _entities(
+        ["Deep Learning for Entity Matching Design", "Something Else Entirely"],
+        id_offset=100,
+    )
+    true_pairs = {(0, 100)}
+    metrics = tfidf_cosine_baseline(left, right, true_pairs, threshold=0.5)
+    assert metrics["true_positives"] == 1
+    assert metrics["recall"] == 1.0
+
+
+def test_tfidf_cosine_threshold_controls_strictness() -> None:
+    """A higher threshold predicts fewer (or equally many) pairs than a lower one."""
+    left = _entities(["Blue Widget Model X"])
+    right = _entities(["Blue Widget Model Y"], id_offset=100)
+    true_pairs = {(0, 100)}
+    loose = tfidf_cosine_baseline(left, right, true_pairs, threshold=0.1)
+    strict = tfidf_cosine_baseline(left, right, true_pairs, threshold=0.99)
+    loose_predicted = loose["true_positives"] + loose["false_positives"]
+    strict_predicted = strict["true_positives"] + strict["false_positives"]
+    assert strict_predicted <= loose_predicted

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,131 @@
+"""Tests for persistent, hard-capped budget ledgers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from serf.dspy.budget import BudgetExceededError, BudgetLedger, TrackedLM, get_ledger
+
+
+def test_ledger_starts_at_zero(tmp_path: object) -> None:
+    """A freshly created ledger has zero spend and zero calls."""
+    ledger = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    assert ledger.spend_usd == 0.0
+    assert ledger.call_count == 0
+
+
+def test_ledger_persists_across_instances(tmp_path: object) -> None:
+    """Spend survives reattaching to the same ledger file (simulating a
+    process restart), which is the entire point of a hard budget guard."""
+    ledger = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    ledger.record(1.5)
+    ledger.record(2.5)
+
+    reattached = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    assert reattached.spend_usd == 4.0
+    assert reattached.call_count == 2
+
+
+def test_record_zero_cost_does_not_increase_spend(tmp_path: object) -> None:
+    """A cache hit (cost 0.0) is still counted as a call but adds no spend."""
+    ledger = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    ledger.record(0.0)
+    assert ledger.spend_usd == 0.0
+    assert ledger.call_count == 1
+
+
+def test_check_raises_once_cap_reached(tmp_path: object) -> None:
+    """check() raises BudgetExceededError once cumulative spend >= cap."""
+    ledger = BudgetLedger("test", cap_usd=5.0, ledger_dir=str(tmp_path))
+    ledger.check()  # no spend yet, should not raise
+    ledger.record(5.0)
+    with pytest.raises(BudgetExceededError):
+        ledger.check()
+
+
+def test_get_ledger_reads_cap_from_config() -> None:
+    """get_ledger builds a BudgetLedger using budget.<name>.cap_usd from config.yml."""
+    ledger = get_ledger("gemini")
+    assert ledger.cap_usd == 100.0
+    assert ledger.name == "gemini"
+
+
+def test_get_ledger_unknown_name_raises() -> None:
+    """An unconfigured ledger name is a programming error, not silently ignored."""
+    with pytest.raises(KeyError):
+        get_ledger("does_not_exist_in_config")
+
+
+def test_tracked_lm_records_real_cost_after_call(tmp_path: object) -> None:
+    """TrackedLM.update_history records the litellm-computed cost into the ledger."""
+    ledger = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    lm = TrackedLM("gemini/gemini-3.5-flash-lite", ledger=ledger, api_key="fake")
+    lm.update_history({"cost": 0.0042})
+    assert ledger.spend_usd == pytest.approx(0.0042)
+
+
+def test_tracked_lm_treats_missing_cost_as_zero(tmp_path: object) -> None:
+    """A cache hit has cost=None in its history entry; that must not crash
+    or be treated as an unknown/non-zero charge."""
+    ledger = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    lm = TrackedLM("gemini/gemini-3.5-flash-lite", ledger=ledger, api_key="fake")
+    lm.update_history({"cost": None})
+    assert ledger.spend_usd == 0.0
+    assert ledger.call_count == 1
+
+
+def test_tracked_lm_call_rejected_once_ledger_exhausted(tmp_path: object) -> None:
+    """__call__ checks the ledger and raises before ever reaching the network
+    once the cap is already exhausted."""
+    ledger = BudgetLedger("test", cap_usd=1.0, ledger_dir=str(tmp_path))
+    ledger.record(1.0)
+    lm = TrackedLM("gemini/gemini-3.5-flash-lite", ledger=ledger, api_key="fake")
+
+    with (
+        patch("dspy.LM.__call__", return_value=["should not be reached"]) as mock_call,
+        pytest.raises(BudgetExceededError),
+    ):
+        lm("some prompt")
+    mock_call.assert_not_called()
+
+
+def test_tracked_lm_call_allowed_under_cap(tmp_path: object) -> None:
+    """__call__ passes through to dspy.LM.__call__ when under the cap."""
+    ledger = BudgetLedger("test", cap_usd=10.0, ledger_dir=str(tmp_path))
+    lm = TrackedLM("gemini/gemini-3.5-flash-lite", ledger=ledger, api_key="fake")
+
+    with patch("dspy.LM.__call__", return_value=["ok"]) as mock_call:
+        result = lm("some prompt")
+    mock_call.assert_called_once()
+    assert result == ["ok"]
+
+
+def test_matcher_uses_gemini_ledger_for_gemini_model() -> None:
+    """EntityMatcher routes Gemini models to the 'gemini' ledger."""
+    from serf.match.matcher import EntityMatcher
+
+    matcher = EntityMatcher(model="gemini/gemini-3.5-flash-lite")
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+        lm = matcher._ensure_lm()
+    assert isinstance(lm, TrackedLM)
+    assert lm.ledger.name == "gemini"
+
+
+def test_matcher_uses_gpt_oss_ledger_for_gpt_oss_model() -> None:
+    """EntityMatcher routes gpt-oss models to their own separate ledger,
+    never the Gemini cap (docs/SERF_LONG_SHOT_PLAN.md Section 9.6, rule 6)."""
+    from serf.match.matcher import EntityMatcher
+
+    matcher = EntityMatcher(model="openai/gpt-oss-120b-maas")
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
+        lm = matcher._ensure_lm()
+    assert isinstance(lm, TrackedLM)
+    assert lm.ledger.name == "gpt_oss_120b_maas"
+
+
+def test_tracked_lm_is_a_magicmock_safe_subclass() -> None:
+    """Sanity check that TrackedLM can be constructed without a real API key
+    reaching the network (no call made at construction time)."""
+    with patch("dspy.LM.__init__", return_value=None) as mock_init:
+        TrackedLM("gemini/gemini-3.5-flash-lite", ledger=MagicMock(), api_key="fake")
+    mock_init.assert_called_once()

--- a/tests/test_dspy.py
+++ b/tests/test_dspy.py
@@ -1,4 +1,4 @@
-"""Tests for DSPy integration with the XMLAdapter."""
+"""Tests for DSPy integration with RobustXMLAdapter."""
 
 import os
 from collections.abc import Generator
@@ -6,21 +6,23 @@ from collections.abc import Generator
 import dspy
 import pytest
 
+from serf.dspy.adapters import RobustXMLAdapter
+
 
 @pytest.fixture
 def lm() -> Generator[dspy.LM, None, None]:
-    """Get the XMLAdapter style language model."""
+    """Get the RobustXMLAdapter style language model."""
     GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
     if not GEMINI_API_KEY:
         raise ValueError("GEMINI_API_KEY environment variable is not set")
 
     lm = dspy.LM("gemini/gemini-3.5-flash-lite", api_key=GEMINI_API_KEY)
-    dspy.configure(lm=lm, adapter=dspy.XMLAdapter())
+    dspy.configure(lm=lm, adapter=RobustXMLAdapter())
 
     yield lm
 
 
 def test_dspy_simple_math(lm: dspy.LM) -> None:
-    """Test the integration of dspy with the XMLAdapter."""
+    """Test the integration of dspy with RobustXMLAdapter."""
     math = dspy.ChainOfThought("question -> answer: float")
     math(question="Two dice are tossed. What is the probability that the sum equals two?")

--- a/tests/test_id_invariants.py
+++ b/tests/test_id_invariants.py
@@ -1,0 +1,307 @@
+"""Tests for the identifier-conservation contract (docs/ID_INVARIANTS.md).
+
+Each test is named for the invariant it protects and mirrors one of the
+nine required tests in ID_INVARIANTS.md Section 9. These tests must fail
+if the contract is broken; several fail against the pre-fix implementation
+(see the divergences D1-D8 in that document's Section 8).
+"""
+
+from unittest.mock import patch
+
+from serf.dspy.types import BlockResolution, Entity, EntityBlock
+from serf.match.matcher import EntityMatcher
+from serf.match.uuid_mapper import UUIDMapper
+
+
+def test_round_trip_identifier_conservation() -> None:
+    """Every input identifier appears exactly once in the output: as a
+    master id, or inside exactly one resolved entity's source_ids."""
+    block = EntityBlock(
+        block_key="b1",
+        block_size=4,
+        entities=[
+            Entity(id=10, name="A"),
+            Entity(id=20, name="B"),
+            Entity(id=30, name="C"),
+            Entity(id=40, name="D"),
+        ],
+    )
+    mapper = UUIDMapper()
+    mapped = mapper.map_block(block)
+    # LLM merges mapped 0+1 into master 0, and returns mapped 2 (D) untouched;
+    # mapped 3 is omitted entirely (dropped, recovered via Phase 2).
+    resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[
+            Entity(id=mapped.entities[0].id, name="A", source_ids=[mapped.entities[1].id]),
+            Entity(id=mapped.entities[2].id, name="C"),
+        ],
+        was_resolved=True,
+        original_count=4,
+        resolved_count=2,
+    )
+    restored = mapper.unmap_block(resolution, block)
+
+    # Phase-2-recovered entities are the documented exception to "a master's
+    # own id is excluded from its own source_ids" (ID_INVARIANTS.md Section 5,
+    # Phase 2, point 2): they self-reference by design, so they're accounted
+    # for separately rather than folded into the general master/merge tally.
+    recovered_ids = {
+        e.id for e in restored.resolved_entities if e.match_skip_reason == "missing_in_match_output"
+    }
+    normal_ids = {e.id for e in restored.resolved_entities} - recovered_ids
+    all_source_ids: list[int] = []
+    for e in restored.resolved_entities:
+        if e.id in recovered_ids:
+            continue
+        all_source_ids.extend(e.source_ids or [])
+
+    input_ids = {10, 20, 30, 40}
+    for input_id in input_ids:
+        if input_id in recovered_ids:
+            continue
+        in_master = input_id in normal_ids
+        occurrences = all_source_ids.count(input_id)
+        if in_master:
+            assert occurrences == 0, f"master {input_id} must not also appear in a source_ids list"
+        else:
+            assert occurrences == 1, (
+                f"non-master {input_id} must appear in exactly one source_ids list, found {occurrences}"
+            )
+    # No identifier duplicated across multiple source_ids lists.
+    assert len(all_source_ids) == len(set(all_source_ids))
+
+
+def test_dropped_record_recovered_with_self_provenance() -> None:
+    """A mock LLM omits a record entirely. It comes back with
+    match_skip_reason == 'missing_in_match_output', its original field
+    values, and its own identifier in its own provenance list."""
+    block = EntityBlock(
+        block_key="b1",
+        block_size=2,
+        entities=[
+            Entity(id=100, name="A", description="original description"),
+            Entity(id=200, name="B"),
+        ],
+    )
+    mapper = UUIDMapper()
+    mapped = mapper.map_block(block)
+    # LLM returns only entity B; A is dropped entirely.
+    resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=mapped.entities[1].id, name="B")],
+        was_resolved=True,
+        original_count=2,
+        resolved_count=1,
+    )
+    restored = mapper.unmap_block(resolution, block)
+
+    recovered = [e for e in restored.resolved_entities if e.id == 100]
+    assert len(recovered) == 1
+    recovered_entity = recovered[0]
+    assert recovered_entity.match_skip_reason == "missing_in_match_output"
+    assert recovered_entity.name == "A"
+    assert recovered_entity.description == "original description"
+    assert 100 in (recovered_entity.source_ids or [])
+
+
+def test_dropped_provenance_restored_via_phase_one_recovery() -> None:
+    """A mock LLM returns a record but truncates its source_ids (drops
+    part of its merge history from an earlier round). Phase 1 restores
+    the missing entries from the cached input, without a full re-emit."""
+    block = EntityBlock(
+        block_key="b1",
+        block_size=3,
+        entities=[
+            Entity(id=100, name="A merged-in-round-1", source_ids=[50, 51]),
+            Entity(id=200, name="B"),
+            Entity(id=300, name="C"),
+        ],
+    )
+    mapper = UUIDMapper()
+    mapped = mapper.map_block(block)
+    # The LLM merges A (mapped 0) and B (mapped 1) this round, but its
+    # source_ids only mentions B (1) -- it has no way to know about A's
+    # round-1 provenance [50, 51], since that was stripped before the call.
+    resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[
+            Entity(id=mapped.entities[0].id, name="A+B", source_ids=[mapped.entities[1].id]),
+            Entity(id=mapped.entities[2].id, name="C"),
+        ],
+        was_resolved=True,
+        original_count=3,
+        resolved_count=2,
+    )
+    restored = mapper.unmap_block(resolution, block)
+
+    master = next(e for e in restored.resolved_entities if e.id == 100)
+    assert 200 in (master.source_ids or [])
+    assert 50 in (master.source_ids or [])
+    assert 51 in (master.source_ids or [])
+
+
+def test_second_round_provenance_survives_without_id_collision() -> None:
+    """A record carrying source_ids from round 1 goes through round 2.
+    Its round-1 provenance survives, and none of those identifiers is
+    resolved against a block-local record from round 2."""
+    # Round-2 block: entity 100 already carries round-1 provenance [2],
+    # and this round's OTHER entities happen to map to block-local int 2,
+    # so a stale, unmapped source_id sent to the LLM would collide with
+    # an unrelated real entity.
+    block = EntityBlock(
+        block_key="b1",
+        block_size=4,
+        entities=[
+            Entity(id=100, name="A", source_ids=[2]),  # round-1 provenance
+            Entity(id=500, name="unrelated-1"),
+            Entity(id=2, name="unrelated-2"),  # real id 2 -- collision bait
+            Entity(id=600, name="unrelated-3"),
+        ],
+    )
+    mapper = UUIDMapper()
+    mapped = mapper.map_block(block)
+
+    # The stale source_ids=[2] must never reach the LLM at all.
+    mapped_a = mapped.entities[0]
+    assert mapped_a.source_ids is None or mapped_a.source_ids == []
+
+    # LLM returns everyone untouched (no merges this round).
+    resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[e.model_copy() for e in mapped.entities],
+        was_resolved=False,
+        original_count=4,
+        resolved_count=4,
+    )
+    restored = mapper.unmap_block(resolution, block)
+
+    restored_a = next(e for e in restored.resolved_entities if e.id == 100)
+    restored_unrelated_2 = next(e for e in restored.resolved_entities if e.id == 2)
+    # A's round-1 provenance [2] must survive as-is...
+    assert 2 in (restored_a.source_ids or [])
+    # ...and must NOT be confused with the real, unrelated entity id=2,
+    # which must come back untouched with no borrowed provenance.
+    assert not (restored_unrelated_2.source_ids or [])
+
+
+def test_transitive_accumulation_of_source_ids() -> None:
+    """Master id=1 source_ids=[3,7] merged with id=22 source_ids=[2,4]
+    yields master id=1 with source_ids == {22,3,7,2,4} and 1 is not in
+    its own list."""
+    block = EntityBlock(
+        block_key="b1",
+        block_size=2,
+        entities=[
+            Entity(id=1, name="A", source_ids=[3, 7]),
+            Entity(id=22, name="B", source_ids=[2, 4]),
+        ],
+    )
+    mapper = UUIDMapper()
+    mapped = mapper.map_block(block)
+    resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[
+            Entity(id=mapped.entities[0].id, name="A+B", source_ids=[mapped.entities[1].id]),
+        ],
+        was_resolved=True,
+        original_count=2,
+        resolved_count=1,
+    )
+    restored = mapper.unmap_block(resolution, block)
+    master = restored.resolved_entities[0]
+    assert master.id == 1
+    assert set(master.source_ids or []) == {22, 3, 7, 2, 4}
+    assert 1 not in (master.source_ids or [])
+
+
+def test_singleton_short_circuit_skips_llm_call() -> None:
+    """A block of one produces no LLM call and one output record with
+    match_skip_reason == 'singleton_block' and its original identifier."""
+    matcher = EntityMatcher()
+    block = EntityBlock(block_key="b1", block_size=1, entities=[Entity(id=100, name="A")])
+
+    with patch.object(EntityMatcher, "_ensure_lm") as mock_ensure_lm:
+        resolution = matcher.resolve_block(block)
+
+    mock_ensure_lm.assert_not_called()
+    assert len(resolution.resolved_entities) == 1
+    assert resolution.resolved_entities[0].id == 100
+    assert resolution.resolved_entities[0].match_skip_reason == "singleton_block"
+    assert resolution.was_resolved is False
+
+
+def test_error_recovery_keeps_original_identifiers() -> None:
+    """The LLM raises. All input records come back unchanged with
+    match_skip_reason == 'error_recovery', was_resolved == False, and
+    ORIGINAL identifiers (no new UUID assigned to a block that changed
+    nothing)."""
+    matcher = EntityMatcher()
+    block = EntityBlock(
+        block_key="b1",
+        block_size=2,
+        entities=[
+            Entity(id=100, name="A", uuid="uuid-original-100"),
+            Entity(id=200, name="B", uuid="uuid-original-200"),
+        ],
+    )
+
+    with patch.object(EntityMatcher, "_ensure_lm", side_effect=RuntimeError("LLM down")):
+        resolution = matcher.resolve_block(block)
+
+    assert resolution.was_resolved is False
+    assert len(resolution.resolved_entities) == 2
+    for e in resolution.resolved_entities:
+        assert e.match_skip_reason == "error_recovery"
+    restored_ids = {e.id for e in resolution.resolved_entities}
+    assert restored_ids == {100, 200}
+    restored_uuids = {e.uuid for e in resolution.resolved_entities}
+    assert restored_uuids == {"uuid-original-100", "uuid-original-200"}
+
+
+def test_skip_history_accumulates_across_iterations() -> None:
+    """A record skipped in rounds 1, 2 and 3 ends with
+    match_skip_history == [1, 2, 3]."""
+    block = EntityBlock(
+        block_key="b1",
+        block_size=1,
+        entities=[Entity(id=100, name="A", match_skip_history=[1, 2])],
+    )
+    matcher = EntityMatcher()
+    resolution = matcher.resolve_block(block, iteration=3)
+    assert resolution.resolved_entities[0].match_skip_history == [1, 2, 3]
+
+
+def test_validation_gate_fails_on_dropped_records() -> None:
+    """A synthetic run that drops 1% of records fails the identifier
+    coverage gate; a clean run passes all checks."""
+    from serf.eval.evaluator import evaluate_er_results
+
+    input_ids = set(range(100))
+    clean_resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=i, name=f"E{i}", uuid=f"uuid-{i}") for i in range(100)],
+        was_resolved=False,
+        original_count=100,
+        resolved_count=100,
+    )
+    clean_report = evaluate_er_results(
+        [clean_resolution], original_entity_count=100, input_entity_ids=input_ids
+    )
+    assert clean_report["overall_status"] == "PASS"
+    assert clean_report["identifier_coverage"]["missing_count"] == 0
+
+    # Drop record 0 entirely: absent from output, no match_skip_reason.
+    lossy_resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=i, name=f"E{i}", uuid=f"uuid-{i}") for i in range(1, 100)],
+        was_resolved=False,
+        original_count=100,
+        resolved_count=99,
+    )
+    lossy_report = evaluate_er_results(
+        [lossy_resolution], original_entity_count=100, input_entity_ids=input_ids
+    )
+    assert lossy_report["overall_status"] == "FAIL"
+    assert lossy_report["identifier_coverage"]["missing_count"] == 1
+    assert 0 in lossy_report["identifier_coverage"]["missing_ids"]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -63,7 +63,7 @@ def test_max_output_tokens_read_from_config() -> None:
     matcher = EntityMatcher()
     with (
         patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
-        patch("serf.match.matcher.dspy.LM") as mock_lm,
+        patch("serf.match.matcher.TrackedLM") as mock_lm,
     ):
         matcher._ensure_lm()
     _, kwargs = mock_lm.call_args

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,70 @@
+"""Tests for EntityMatcher's retry and LM configuration behavior."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from serf.dspy.types import BlockResolution, Entity, EntityBlock
+from serf.match.matcher import EntityMatcher
+
+
+def test_retries_recover_from_a_transient_failure() -> None:
+    """A predictor call that fails once and succeeds on retry returns the
+    successful resolution rather than falling back to error_recovery."""
+    matcher = EntityMatcher()
+    block = EntityBlock(
+        block_key="b1",
+        block_size=2,
+        entities=[Entity(id=100, name="A"), Entity(id=200, name="B")],
+    )
+    success = BlockResolution(
+        block_key="b1", resolved_entities=[], was_resolved=False, original_count=2
+    )
+    mock_predictor = MagicMock(
+        side_effect=[RuntimeError("transient"), MagicMock(resolution=success)]
+    )
+
+    with (
+        patch.object(EntityMatcher, "_ensure_lm", return_value=MagicMock()),
+        patch.object(EntityMatcher, "predictor", new_callable=PropertyMock) as mock_prop,
+        patch("time.sleep"),
+    ):
+        mock_prop.return_value = mock_predictor
+        resolution = matcher.resolve_block(block)
+
+    assert mock_predictor.call_count == 2
+    assert all(e.match_skip_reason != "error_recovery" for e in resolution.resolved_entities)
+
+
+def test_exhausting_retries_falls_back_to_error_recovery() -> None:
+    """A predictor that always fails exhausts max_retries and falls back
+    to error_recovery, rather than raising out of resolve_block."""
+    matcher = EntityMatcher()
+    block = EntityBlock(
+        block_key="b1",
+        block_size=2,
+        entities=[Entity(id=100, name="A"), Entity(id=200, name="B")],
+    )
+    mock_predictor = MagicMock(side_effect=RuntimeError("permanent"))
+
+    with (
+        patch.object(EntityMatcher, "_ensure_lm", return_value=MagicMock()),
+        patch.object(EntityMatcher, "predictor", new_callable=PropertyMock) as mock_prop,
+        patch("time.sleep"),
+    ):
+        mock_prop.return_value = mock_predictor
+        resolution = matcher.resolve_block(block)
+
+    assert mock_predictor.call_count == 3  # config default er.matching.max_retries
+    assert all(e.match_skip_reason == "error_recovery" for e in resolution.resolved_entities)
+
+
+def test_max_output_tokens_read_from_config() -> None:
+    """The LM is constructed with er.matching.max_output_tokens (65536 by
+    default), not a small hardcoded value that truncates large blocks."""
+    matcher = EntityMatcher()
+    with (
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        patch("serf.match.matcher.dspy.LM") as mock_lm,
+    ):
+        matcher._ensure_lm()
+    _, kwargs = mock_lm.call_args
+    assert kwargs["max_tokens"] == 65536

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,185 @@
+"""Tests for GEPA optimization data preparation and scoring (no LLM calls)."""
+
+# isort: off
+# numpy must load before dspy: dspy lazily proxies the numpy module, and if
+# something later does `from numpy.typing import X` before numpy has been
+# imported for real, the lazy proxy re-execs numpy's __init__ into an
+# already-partially-loaded module and corrupts its C extension state.
+import numpy  # noqa: F401
+import dspy
+
+# isort: on
+
+from serf.dspy.optimize import (
+    _map_gold_resolution,
+    build_gepa_examples,
+    er_metric,
+    evaluate_program,
+    gold_resolution_for_block,
+    resolution_to_pairs,
+)
+from serf.dspy.types import BlockResolution, Entity, EntityBlock
+from serf.match.uuid_mapper import UUIDMapper
+
+
+def _block(ids: list[int]) -> EntityBlock:
+    return EntityBlock(
+        block_key="b1",
+        block_size=len(ids),
+        entities=[Entity(id=i, name=f"E{i}") for i in ids],
+    )
+
+
+def test_gold_resolution_merges_true_pairs_transitively() -> None:
+    """Entities linked by a chain of true pairs form one component, mastered
+    by the lowest id, exactly like an LLM merge would be expected to."""
+    block = _block([10, 20, 30, 40])
+    ground_truth = {(10, 20), (20, 30)}  # 10-20-30 chain; 40 is a distractor
+    gold = gold_resolution_for_block(block, ground_truth)
+
+    merged = next(e for e in gold.resolved_entities if e.id == 10)
+    assert set(merged.source_ids or []) == {20, 30}
+    standalone = next(e for e in gold.resolved_entities if e.id == 40)
+    assert not standalone.source_ids
+    assert gold.was_resolved is True
+
+
+def test_gold_resolution_no_true_pairs_leaves_everyone_standalone() -> None:
+    """A block with zero true pairs in it resolves to no merges at all."""
+    block = _block([10, 20])
+    gold = gold_resolution_for_block(block, ground_truth=set())
+    assert gold.was_resolved is False
+    assert all(not e.source_ids for e in gold.resolved_entities)
+
+
+def test_resolution_to_pairs_normalizes_order() -> None:
+    """Pairs are always (min, max), matching evaluate_resolution's convention."""
+    resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=5, name="A", source_ids=[2])],
+        original_count=2,
+        resolved_count=1,
+    )
+    assert resolution_to_pairs(resolution) == {(2, 5)}
+
+
+def test_map_gold_resolution_translates_to_mapped_ids() -> None:
+    """The gold label's ids move into the same mapped-id space the block
+    itself was translated into, so the metric compares like with like."""
+    block = _block([100, 200, 300])
+    mapper = UUIDMapper()
+    mapper.map_block(block)
+    gold = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=100, name="A", source_ids=[200])],
+        original_count=3,
+        resolved_count=1,
+    )
+    mapped = _map_gold_resolution(gold, mapper)
+    assert mapped.resolved_entities[0].id == mapper._id_to_int[100]
+    assert mapped.resolved_entities[0].source_ids == [mapper._id_to_int[200]]
+
+
+def test_build_gepa_examples_produces_valid_dspy_examples() -> None:
+    """Each example carries the three BlockMatch inputs and a resolution
+    label whose ids are all valid mapped ids for that same block."""
+    blocks = [_block([10, 20, 30])]
+    ground_truth = {(10, 20)}
+    examples = build_gepa_examples(blocks, ground_truth)
+
+    assert len(examples) == 1
+    ex = examples[0]
+    assert set(ex.inputs().keys()) == {"block_records", "schema_info", "few_shot_examples"}
+    assert isinstance(ex.resolution, BlockResolution)
+    mapped_ids = {1, 2, 3}  # 1-based mapping, per docs/ID_INVARIANTS.md D6
+    for e in ex.resolution.resolved_entities:
+        assert e.id in mapped_ids
+        for sid in e.source_ids or []:
+            assert sid in mapped_ids
+
+
+def test_er_metric_perfect_prediction_scores_one() -> None:
+    """An exact match to gold scores 1.0 with no missed/extra feedback."""
+    gold_resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=1, name="A", source_ids=[2])],
+        original_count=2,
+        resolved_count=1,
+    )
+    gold = dspy.Example(resolution=gold_resolution)
+    pred = dspy.Prediction(resolution=gold_resolution.model_copy())
+    result = er_metric(gold, pred)
+    assert result.score == 1.0
+    assert "Missed" not in result.feedback
+    assert "Incorrectly merged" not in result.feedback
+
+
+def test_er_metric_missed_match_scores_less_than_one() -> None:
+    """A prediction that fails to merge a true pair is penalized and the
+    feedback names the missed pair, for the reflection_lm to read."""
+    gold_resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=1, name="A", source_ids=[2])],
+        original_count=2,
+        resolved_count=1,
+    )
+    pred_resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=1, name="A"), Entity(id=2, name="B")],
+        original_count=2,
+        resolved_count=2,
+    )
+    gold = dspy.Example(resolution=gold_resolution)
+    pred = dspy.Prediction(resolution=pred_resolution)
+    result = er_metric(gold, pred)
+    assert result.score < 1.0
+    assert "Missed 1 true match" in result.feedback
+
+
+def test_er_metric_malformed_prediction_scores_zero() -> None:
+    """A prediction missing the resolution field fails gracefully to 0.0
+    rather than raising out of the optimizer's evaluation loop."""
+    gold = dspy.Example(
+        resolution=BlockResolution(block_key="b1", original_count=1, resolved_count=1)
+    )
+    pred = dspy.Prediction()  # no `resolution` attribute at all
+    result = er_metric(gold, pred)
+    assert result.score == 0.0
+
+
+def test_evaluate_program_averages_scores_across_examples() -> None:
+    """evaluate_program calls the program per-example and averages er_metric."""
+    gold_resolution = BlockResolution(
+        block_key="b1",
+        resolved_entities=[Entity(id=1, name="A", source_ids=[2])],
+        original_count=2,
+        resolved_count=1,
+    )
+    example = dspy.Example(
+        block_records="[]",
+        schema_info="",
+        few_shot_examples="",
+        resolution=gold_resolution,
+    ).with_inputs("block_records", "schema_info", "few_shot_examples")
+
+    def fake_program(**kwargs: object) -> dspy.Prediction:
+        return dspy.Prediction(resolution=gold_resolution.model_copy())
+
+    avg_f1 = evaluate_program(fake_program, [example])
+    assert avg_f1 == 1.0
+
+
+def test_evaluate_program_handles_exceptions_as_zero() -> None:
+    """A program call that raises counts as a 0.0, not a crashed evaluation."""
+
+    def failing_program(**kwargs: object) -> dspy.Prediction:
+        raise RuntimeError("boom")
+
+    example = dspy.Example(
+        block_records="[]",
+        schema_info="",
+        few_shot_examples="",
+        resolution=BlockResolution(block_key="b1", original_count=1, resolved_count=1),
+    ).with_inputs("block_records", "schema_info", "few_shot_examples")
+    avg_f1 = evaluate_program(failing_program, [example])
+    assert avg_f1 == 0.0

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -189,6 +189,16 @@ def test_evaluate_program_handles_exceptions_as_zero() -> None:
     assert avg_f1 == 0.0
 
 
+def test_gold_resolution_handles_blocks_with_no_true_pairs() -> None:
+    """A block with no true pair (the require_true_pair=False case) still
+    produces a valid gold resolution: everyone standalone, was_resolved=False."""
+    block = _block([10, 20, 30])
+    gold = gold_resolution_for_block(block, ground_truth=set())
+    assert gold.was_resolved is False
+    assert len(gold.resolved_entities) == 3
+    assert all(e.source_ids is None for e in gold.resolved_entities)
+
+
 def test_build_tracked_lm_routes_gemini_model_to_gemini_ledger() -> None:
     """A gemini/* model is billed against the 'gemini' ledger using
     GEMINI_API_KEY, never Vertex AI credentials."""

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -9,7 +9,12 @@ import dspy
 
 # isort: on
 
+from unittest.mock import patch
+
+import pytest
+
 from serf.dspy.optimize import (
+    _build_tracked_lm,
     _map_gold_resolution,
     build_gepa_examples,
     er_metric,
@@ -182,3 +187,36 @@ def test_evaluate_program_handles_exceptions_as_zero() -> None:
     ).with_inputs("block_records", "schema_info", "few_shot_examples")
     avg_f1 = evaluate_program(failing_program, [example])
     assert avg_f1 == 0.0
+
+
+def test_build_tracked_lm_routes_gemini_model_to_gemini_ledger() -> None:
+    """A gemini/* model is billed against the 'gemini' ledger using
+    GEMINI_API_KEY, never Vertex AI credentials."""
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}, clear=False):
+        lm = _build_tracked_lm("gemini/gemini-3.5-flash-lite", temperature=0.0, max_tokens=100)
+    assert lm.ledger.name == "gemini"
+
+
+def test_build_tracked_lm_gpt_oss_without_project_raises_actionable_error() -> None:
+    """Requesting a gpt-oss-*-maas model without GOOGLE_CLOUD_PROJECT set
+    fails with a clear, actionable message (docs/SERF_LONG_SHOT_PLAN.md
+    Section 7.9), not a bare KeyError."""
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        pytest.raises(ValueError, match="GOOGLE_CLOUD_PROJECT"),
+    ):
+        _build_tracked_lm("openai/gpt-oss-120b-maas", temperature=0.0, max_tokens=100)
+
+
+def test_build_tracked_lm_gpt_oss_routes_to_separate_ledger() -> None:
+    """A gpt-oss-*-maas model is billed against its own ledger, never the
+    Gemini $100 cap (docs/SERF_LONG_SHOT_PLAN.md Section 9.6, rule 6)."""
+    import google.auth
+
+    fake_creds = type("FakeCreds", (), {"token": "fake-token", "refresh": lambda self, req: None})()
+    with (
+        patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "fake-project"}, clear=False),
+        patch.object(google.auth, "default", return_value=(fake_creds, "fake-project")),
+    ):
+        lm = _build_tracked_lm("openai/gpt-oss-120b-maas", temperature=0.0, max_tokens=100)
+    assert lm.ledger.name == "gpt_oss_120b_maas"

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,10 +1,9 @@
 """Tests for GEPA optimization data preparation and scoring (no LLM calls)."""
 
 # isort: off
-# numpy must load before dspy: dspy lazily proxies the numpy module, and if
-# something later does `from numpy.typing import X` before numpy has been
-# imported for real, the lazy proxy re-execs numpy's __init__ into an
-# already-partially-loaded module and corrupts its C extension state.
+# numpy must load before dspy in a fresh process -- see the matching comment
+# in src/serf/dspy/optimize.py. That module's own guard only helps if this
+# file hasn't already triggered dspy's lazy numpy proxy first.
 import numpy  # noqa: F401
 import dspy
 

--- a/tests/test_uuid_mapper.py
+++ b/tests/test_uuid_mapper.py
@@ -5,7 +5,8 @@ from serf.match.uuid_mapper import UUIDMapper
 
 
 def test_map_block_replaces_ids_with_consecutive_ints() -> None:
-    """map_block replaces entity IDs with 0, 1, 2, ..."""
+    """map_block replaces entity IDs with 1, 2, 3, ... (not 0-based: models
+    conflate 0 with null/absent in structured output)."""
     block = EntityBlock(
         block_key="b1",
         block_size=3,
@@ -17,9 +18,10 @@ def test_map_block_replaces_ids_with_consecutive_ints() -> None:
     )
     mapper = UUIDMapper()
     mapped = mapper.map_block(block)
-    assert [e.id for e in mapped.entities] == [0, 1, 2]
+    assert [e.id for e in mapped.entities] == [1, 2, 3]
     assert [e.name for e in mapped.entities] == ["A", "B", "C"]
     assert all(e.source_uuids is None for e in mapped.entities)
+    assert all(e.source_ids is None for e in mapped.entities)
 
 
 def test_map_block_strips_source_uuids() -> None:
@@ -51,8 +53,9 @@ def test_unmap_block_restores_ids_and_source_uuids() -> None:
     resolution = BlockResolution(
         block_key="b1",
         resolved_entities=[
-            Entity(id=0, name="A merged", source_ids=[1]),
+            Entity(id=1, name="A merged", source_ids=[2]),
         ],
+        was_resolved=True,
         original_count=2,
         resolved_count=1,
     )
@@ -75,12 +78,13 @@ def test_unmap_block_recovers_missing_entities_as_singletons() -> None:
     )
     mapper = UUIDMapper()
     mapper.map_block(block)
-    # LLM only returned entity 0 (A merged with B), entity 2 (C) is missing
+    # LLM only returned mapped entity 1 (A merged with B), mapped 3 (C) is missing
     resolution = BlockResolution(
         block_key="b1",
         resolved_entities=[
-            Entity(id=0, name="A", source_ids=[1]),
+            Entity(id=1, name="A", source_ids=[2]),
         ],
+        was_resolved=True,
         original_count=3,
         resolved_count=1,
     )
@@ -88,14 +92,14 @@ def test_unmap_block_recovers_missing_entities_as_singletons() -> None:
     # Should have 2 entities: A (merged with B) + C (recovered singleton)
     assert len(restored.resolved_entities) == 2
     # The merged entity keeps its source_ids
-    merged = restored.resolved_entities[0]
-    assert merged.id == 100
+    merged = next(e for e in restored.resolved_entities if e.id == 100)
     assert 200 in (merged.source_ids or [])
-    # The recovered entity is a singleton with match_skip
+    # The recovered entity is a singleton with match_skip, self-referenced
     recovered = [e for e in restored.resolved_entities if e.match_skip_reason]
     assert len(recovered) == 1
     assert recovered[0].id == 300
     assert recovered[0].match_skip_reason == "missing_in_match_output"
+    assert 300 in (recovered[0].source_ids or [])
 
 
 def test_unmap_block_deduplicates_source_ids() -> None:
@@ -114,13 +118,14 @@ def test_unmap_block_deduplicates_source_ids() -> None:
     resolution = BlockResolution(
         block_key="b1",
         resolved_entities=[
-            Entity(id=0, name="A merged", source_ids=[1, 2]),
+            Entity(id=1, name="A merged", source_ids=[2, 3]),
         ],
+        was_resolved=True,
         original_count=3,
         resolved_count=1,
     )
     restored = mapper.unmap_block(resolution, block)
-    merged = restored.resolved_entities[0]
+    merged = next(e for e in restored.resolved_entities if e.id == 100)
     assert merged.source_ids is not None
     assert len(merged.source_ids) == len(set(merged.source_ids))
 
@@ -140,8 +145,9 @@ def test_unmap_block_excludes_master_id_from_source_ids() -> None:
     resolution = BlockResolution(
         block_key="b1",
         resolved_entities=[
-            Entity(id=0, name="A merged", source_ids=[1]),
+            Entity(id=1, name="A merged", source_ids=[2]),
         ],
+        was_resolved=True,
         original_count=2,
         resolved_count=1,
     )
@@ -171,8 +177,9 @@ def test_unmap_block_accumulates_source_uuids_transitively() -> None:
     resolution = BlockResolution(
         block_key="b1",
         resolved_entities=[
-            Entity(id=0, name="A merged", source_ids=[1]),
+            Entity(id=1, name="A merged", source_ids=[2]),
         ],
+        was_resolved=True,
         original_count=2,
         resolved_count=1,
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moving from planning to build mode: implementing Karpathy's research loop (`docs/RESEARCH_LOOP.md`) and using `dspy.GEPA` to optimize SERF's ER signatures, per direct instruction.

## Setup
- Pulled `MISSION.md`, `CODING_STANDARDS.md`, `ID_INVARIANTS.md`, `RESEARCH_LOOP.md` in from the still-open, not-yet-merged documentation PR ([#19](https://github.com/Graphlet-AI/serf/pull/19)) as reference docs for this build — without touching that PR's other in-progress changes.
- `.cursor/scratchpad.md`: live task breakdown and progress log for this effort (Planner/Executor format).
- Budget: hard cap of **$100 total** in Gemini/GCP credits. **$40.27 spent** (Gemini ledger), **$0** (gpt-oss-120b-maas ledger), enforced by a real, persistent, file-backed ledger checked before every call.

## Stage 1 — Correctness first
Per the research loop's Stage 1 ("get the evaluation harness producing numbers you trust — nothing else matters until this works"), fixed real bugs found in `docs/ID_INVARIANTS.md`'s audit of the identifier-conservation contract, verified empirically (wrote the 9 required tests first, confirmed which ones actually failed against the pre-fix code, then fixed):

- **D1**: `source_ids` now cleared before the LLM call (not just `uuid`/`source_uuids`) — a prior round's real-id provenance was colliding with the current round's block-local mapped integers, corrupting merges from iteration 2 onward.
- **D4**: singleton blocks now short-circuit before any LLM call.
- **D5**: new UUIDs are only assigned when a block was actually resolved, so error-recovery/singleton blocks keep their original identity.
- **D6**: mapped integers start at 1, not 0.
- **D7**: added the retry loop `config.yml` already declared but nothing implemented.
- Forced a Phase-2-recovered entity's own id into its own `source_ids`, per the documented recovery contract (previously missing).
- Fixed the `max_tokens=8192` hardcode `RESEARCH_LOOP.md` flagged as causing real truncation-driven record loss — now configurable, default 65536 (Gemini 3.5 Flash-Lite's actual max output).
- Added a genuine identifier-coverage gate to `evaluate_er_results` — the existing check only validated that emitted references were valid, not that every input id was accounted for anywhere in the output.

D2/D3 from the audit were written up as tests too, but found to already be handled correctly by this implementation's existing restoration logic (kept as regression coverage). D8 (dead `min_block_size` config) deferred — low severity, no data-loss risk.

## Infrastructure and baselines
- `src/serf/dspy/budget.py`: `BudgetLedger` (file-backed under `data/budget/`, survives restarts) and `TrackedLM` (a `dspy.LM` subclass recording litellm's own computed per-call cost). LM response caching needed no new code — `dspy.LM(cache=True)` is already the default, backed by a persistent on-disk cache.
- `src/serf/eval/baselines.py` + `serf baselines` CLI command: random, exact-name-match, and TF-IDF cosine baselines (vectorized, scale to DBLP-Scholar's ~168M candidate pairs), plus the blocking recall ceiling. Ran on `dblp-acm` and `abt-buy`; a genuinely surprising finding (raising `target_block_size` from 30 to 100 made DBLP-ACM's recall ceiling *worse*, 0.83 → 0.53) is logged in `experiments/log.md`.
- `src/serf/dspy/adapters.py`'s `RobustXMLAdapter`: found and fixed a real parsing failure mode during GEPA validation — `dspy.XMLAdapter` failed to parse model output containing unescaped `&` characters (~10% of DBLP-ACM's records). Now used everywhere `XMLAdapter` was.

## GEPA optimization — two real, honestly-reported results
`src/serf/dspy/optimize.py` builds labeled training blocks from a benchmark's ground truth (real FAISS blocking, gold resolutions via union-find over the ground-truth match relation), an `er_metric` scoring pairwise F1 with textual feedback, and wires it into `dspy.GEPA` against a sealed test split.

1. **Small, curated set (13 blocks, distractor-mixed):** `baseline_f1 = 0.95` → `optimized_f1 = 1.00` on a 4-example sealed test set. Directionally positive, but logged with an explicit caveat: n_test=4 is too small to be confident, and the evolved instructions' specific brand/model examples suggest partial memorization of the tiny training set rather than fully general learning.
2. **Full dataset, all 98 blocks (49/24/25 split), run per explicit instruction for "a much larger training set":** `baseline_f1 == optimized_f1 == 0.4701` — GEPA proposed and evaluated 6+ candidate instructions against validation, none beat the hand-written original, so it correctly kept the baseline. A genuine negative result, reported as such per the research loop's own honesty rules ("say when a number is worse than the baseline").

Both are logged in full in `experiments/log.md` with hypothesis/command/cost/verdict, per the required format.

## Blocked: `gpt-oss-120b-maas`
Per instruction, the intended configuration is teacher=`gemini-3.5-flash-lite`, student=`gpt-oss-120b-maas`. That model requires Vertex AI access (`GOOGLE_CLOUD_PROJECT` + Application Default Credentials); this environment only has `GEMINI_API_KEY` configured. `_build_tracked_lm()` fully implements and tests both routing paths (including the missing-credential failure mode with an actionable error message), but cannot be exercised against the real endpoint without those credentials. Per explicit follow-up instruction, continuing with `gemini-3.5-flash-lite` as a stand-in student until Vertex AI credentials are added.

## Next
- Once Vertex AI credentials are available: run the intended teacher/student configuration.
- Test whether `max_metric_calls` was the binding constraint on the null result (larger budget sweep).
- Consider `dspy.Flex` (Section 7.8 of the plan doc) if instruction-only optimization has hit its ceiling.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1aa734e-882b-4cd1-9c90-d23b0e46e135?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1aa734e-882b-4cd1-9c90-d23b0e46e135&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

